### PR TITLE
Add support for link colors

### DIFF
--- a/.storybook/Link.js
+++ b/.storybook/Link.js
@@ -13,3 +13,8 @@ storiesOf('Link', module)
       Open the Priceline Home in the same window
     </Link>
   ))
+  .add('Color', () => (
+    <Link color='gray3'>
+      I'm a different color!
+    </Link>
+  ))

--- a/src/Link.js
+++ b/src/Link.js
@@ -1,13 +1,23 @@
 import styled from 'styled-components'
+import PropTypes from 'prop-types'
+import { color } from 'styled-system'
 
 const Link = styled.a`
   text-decoration: none;
-  color: ${props => props.theme.colors.blue};
+  ${color}
   &:hover {
     text-decoration: underline;
   }
 `
 
 Link.displayName = 'Link'
+
+Link.propTypes = {
+  color: PropTypes.string
+}
+
+Link.defaultProps = {
+  color: 'blue'
+}
 
 export default Link

--- a/src/__tests__/__snapshots__/Flex.js.snap
+++ b/src/__tests__/__snapshots__/Flex.js.snap
@@ -23,9 +23,9 @@ exports[`Flex justify prop 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: space-between;
+  -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 

--- a/src/__tests__/__snapshots__/Flex.js.snap
+++ b/src/__tests__/__snapshots__/Flex.js.snap
@@ -23,9 +23,9 @@ exports[`Flex justify prop 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: justify;
+  -webkit-box-pack: space-between;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
+  -ms-flex-pack: space-between;
   justify-content: space-between;
 }
 

--- a/src/__tests__/__snapshots__/Link.js.snap
+++ b/src/__tests__/__snapshots__/Link.js.snap
@@ -24,6 +24,7 @@ exports[`Link renders 1`] = `
 >
   <a
     className="c1"
+    color="blue"
   >
     Dummy
   </a>


### PR DESCRIPTION
The current `Link` implementation doesn't account for different color links. The `:hover` property will get out-of-sync with text color changes.