### PR TITLE
Removed usage of Object.assign in favor of object spread

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-design-system",
-  "version": "1.0.0-7",
+  "version": "1.0.0-6",
   "description": "Priceline Design System",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-design-system",
-  "version": "1.0.0-6",
+  "version": "1.0.0-7",
   "description": "Priceline Design System",
   "main": "dist/index.js",
   "scripts": {

--- a/src/legacyTheme.js
+++ b/src/legacyTheme.js
@@ -71,6 +71,5 @@ export const colors = {
   orange3
 }
 
-const legacyTheme = {...theme, colors: {...colors}}
-
+const legacyTheme = {...theme, colors}
 export default legacyTheme

--- a/src/legacyTheme.js
+++ b/src/legacyTheme.js
@@ -71,8 +71,6 @@ export const colors = {
   orange3
 }
 
-const legacyTheme = Object.assign({}, theme, {
-  colors
-})
+const legacyTheme = {...theme, colors: {...colors}}
 
 export default legacyTheme

--- a/src/theme.js
+++ b/src/theme.js
@@ -6,7 +6,7 @@ const addAliases = (arr, aliases) =>
   aliases.forEach((key, i) =>
     Object.defineProperty(arr, key, {
       enumerable: false,
-      get() {
+      get () {
         return this[i]
       }
     })
@@ -69,9 +69,12 @@ const purple = '#7600bb'
 
 // tints
 const flatten = (name, colors) => colors
-  .reduce((a, b, i) => Object.assign(a, {
-    [name + i]: b
-  }), {})
+  .reduce((a, b, i) => {
+    const color = {
+      [name + i]: b
+    }
+    return {...a, ...color}
+  }, {})
 
 const tints = [
   0.2,
@@ -86,7 +89,7 @@ const reds = tints.map(tint(red))
 const oranges = tints.map(tint(orange))
 const purples = tints.map(tint(purple))
 
-export const colors = Object.assign({}, {
+export const colors = {...{
   black,
   white,
   text,
@@ -102,13 +105,13 @@ export const colors = Object.assign({}, {
   oranges,
   purples
 },
-  flatten('blue', blues),
-  flatten('gray', grays),
-  flatten('green', greens),
-  flatten('red', reds),
-  flatten('orange', oranges),
-  flatten('purple', purples)
-)
+  ...flatten('blue', blues),
+  ...flatten('gray', grays),
+  ...flatten('green', greens),
+  ...flatten('red', reds),
+  ...flatten('orange', oranges),
+  ...flatten('purple', purples)
+}
 
 export const radius = '2px'
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -89,7 +89,7 @@ const reds = tints.map(tint(red))
 const oranges = tints.map(tint(orange))
 const purples = tints.map(tint(purple))
 
-export const colors = {...{
+export const colors = {
   black,
   white,
   text,
@@ -103,8 +103,7 @@ export const colors = {...{
   greens,
   reds,
   oranges,
-  purples
-},
+  purples,
   ...flatten('blue', blues),
   ...flatten('gray', grays),
   ...flatten('green', greens),


### PR DESCRIPTION
Converted the Object.assign usages with usages of the spread operator. This should prevent some issues with IE11 since this will be transpiled by babel