### PR TITLE
Add webkit-font-smoothing to Button component

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -34,6 +34,7 @@ const size = props => {
 const fullWidth = props => props.fullWidth ? ({ width: '100%' }) : null
 
 const Button = styled.button`
+  -webkit-font-smoothing: antialiased;
   display: inline-block;
   vertical-align: middle;
   text-align: center;

--- a/src/__tests__/__snapshots__/Button.js.snap
+++ b/src/__tests__/__snapshots__/Button.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Button fullWidth prop sets width to 100% 1`] = `
 .c0 {
+  -webkit-font-smoothing: antialiased;
   display: inline-block;
   vertical-align: middle;
   text-align: center;
@@ -31,6 +32,7 @@ exports[`Button fullWidth prop sets width to 100% 1`] = `
 
 exports[`Button renders 1`] = `
 .c0 {
+  -webkit-font-smoothing: antialiased;
   display: inline-block;
   vertical-align: middle;
   text-align: center;
@@ -59,6 +61,7 @@ exports[`Button renders 1`] = `
 
 exports[`Button size large sets height and font-size 1`] = `
 .c0 {
+  -webkit-font-smoothing: antialiased;
   display: inline-block;
   vertical-align: middle;
   text-align: center;
@@ -88,6 +91,7 @@ exports[`Button size large sets height and font-size 1`] = `
 
 exports[`Button size medium sets height and font-size 1`] = `
 .c0 {
+  -webkit-font-smoothing: antialiased;
   display: inline-block;
   vertical-align: middle;
   text-align: center;
@@ -117,6 +121,7 @@ exports[`Button size medium sets height and font-size 1`] = `
 
 exports[`Button size small sets height and font-size 1`] = `
 .c0 {
+  -webkit-font-smoothing: antialiased;
   display: inline-block;
   vertical-align: middle;
   text-align: center;

--- a/src/__tests__/__snapshots__/GreenButton.js.snap
+++ b/src/__tests__/__snapshots__/GreenButton.js.snap
@@ -2,6 +2,7 @@
 
 exports[`GreenButton renders 1`] = `
 .c1 {
+  -webkit-font-smoothing: antialiased;
   display: inline-block;
   vertical-align: middle;
   text-align: center;

--- a/src/__tests__/__snapshots__/OutlineButton.js.snap
+++ b/src/__tests__/__snapshots__/OutlineButton.js.snap
@@ -2,6 +2,7 @@
 
 exports[`OutlineButton renders 1`] = `
 .c1 {
+  -webkit-font-smoothing: antialiased;
   display: inline-block;
   vertical-align: middle;
   text-align: center;

--- a/src/__tests__/__snapshots__/RedButton.js.snap
+++ b/src/__tests__/__snapshots__/RedButton.js.snap
@@ -2,6 +2,7 @@
 
 exports[`RedButton renders 1`] = `
 .c1 {
+  -webkit-font-smoothing: antialiased;
   display: inline-block;
   vertical-align: middle;
   text-align: center;


### PR DESCRIPTION
## Done

Add webkit-font-smoothing to Button component 

## QA

- Pull this feature branch
- Run `npm i`
- Run `npm test` - verify no failures
- Run `npm start`
- View [Button component](http://localhost:8000/?selectedKind=Button&selectedStory=Button%20component&full=0&down=1&left=1&panelRight=0&downPanel=storybook%2Factions%2Factions-panel) in Storybook
- Verify the font-smoothing rule is being applied to buttons

<img width="1359" alt="screen shot 2017-10-19 at 16 38 23" src="https://user-images.githubusercontent.com/505570/31779845-ffafd9c4-b4eb-11e7-9e89-a499bd3b1e23.png">

## Issue

Fixes #102

## Hacktoberfest

I submit this fix in support of [Hacktoberfest](https://hacktoberfest.digitalocean.com/). I usually work on our own open source design system, [Vanilla Framework](https://github.com/vanilla-framework/vanilla-framework) 👋🏻