### PR TITLE
Add customBreakpoints prop to ThemeProvider - fixes #156

### DIFF
--- a/docs/ThemeProvider.md
+++ b/docs/ThemeProvider.md
@@ -3,4 +3,22 @@
 
 The ThemeProvider component is a wrapper around the styled-components' [ThemeProvider][sc-theme]
 
+Wrap the root of your application with the `ThemeProvider` component,
+which adds the Design System theme to context for use in styled-components
+and sets typographic defaults.
+This should only be included once in your application.
+
+```jsx
+<ThemeProvider>
+  <Heading>
+    Hello
+  </Heading>
+</ThemeProvider>
+```
+
+Prop | Type | Description
+---|---|---
+`legacy` | Boolean | Enable legacy color palette
+`customBreakpoints` | Array | Array of em number values to override default breakpoints
+
 [sc-theme]: https://www.styled-components.com/docs/advanced#theming

--- a/src/ThemeProvider.js
+++ b/src/ThemeProvider.js
@@ -20,13 +20,9 @@ export const Base = styled.div`
   }
 `
 
-export const pxToEm = n => n / 16
-
 const ThemeProvider = ({ legacy, customBreakpoints, ...props }) => {
   const baseTheme = legacy ? legacyTheme : nextTheme
-  const breakpoints = customBreakpoints
-    ? customBreakpoints.map(pxToEm)
-    : baseTheme.breakpoints
+  const breakpoints = customBreakpoints || baseTheme.breakpoints
   const theme = {
     ...baseTheme,
     breakpoints

--- a/src/ThemeProvider.js
+++ b/src/ThemeProvider.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled, {
   ThemeProvider as StyledThemeProvider,
   injectGlobal
@@ -19,14 +20,30 @@ export const Base = styled.div`
   }
 `
 
-const ThemeProvider = ({ legacy, ...props }) => {
-  const theme = legacy ? legacyTheme : nextTheme
+export const pxToEm = n => n / 16
+
+const ThemeProvider = ({ legacy, customBreakpoints, ...props }) => {
+  const baseTheme = legacy ? legacyTheme : nextTheme
+  const breakpoints = customBreakpoints
+    ? customBreakpoints.map(pxToEm)
+    : baseTheme.breakpoints
+  const theme = {
+    ...baseTheme,
+    breakpoints
+  }
 
   return (
     <StyledThemeProvider theme={theme}>
       <Base {...props} />
     </StyledThemeProvider>
   )
+}
+
+ThemeProvider.propTypes = {
+  /** Enable legacy color palette */
+  legacy: PropTypes.bool,
+  /** Array of pixel values for custom breakpoint overrides */
+  customBreakpoints: PropTypes.arrayOf(PropTypes.number)
 }
 
 export default ThemeProvider

--- a/src/__tests__/ThemeProvider.js
+++ b/src/__tests__/ThemeProvider.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { ThemeProvider, theme, Box } from '..'
-import { Base, pxToEm } from '../ThemeProvider'
+import { Base } from '../ThemeProvider'
 
 describe('ThemeProvider', () => {
   test('renders', () => {
@@ -20,15 +20,10 @@ describe('ThemeProvider', () => {
     expect(json).toHaveStyleRule('font-family', theme.font)
   })
 
-  test('pxToEm converts pixel values to em', () => {
-    const em = pxToEm(256)
-    expect(em).toEqual(16)
-  })
-
   test('accepts a custom breakpoints prop', () => {
     const json = renderer
       .create(
-        <ThemeProvider customBreakpoints={[320, 512, 768, 1024]}>
+        <ThemeProvider customBreakpoints={[20, 32, 48, 64]}>
           <Box width={[1, 1 / 2, 1 / 4]} />
         </ThemeProvider>
       )

--- a/src/__tests__/ThemeProvider.js
+++ b/src/__tests__/ThemeProvider.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { ThemeProvider, theme } from '..'
-import { Base } from '../ThemeProvider'
+import { ThemeProvider, theme, Box } from '..'
+import { Base, pxToEm } from '../ThemeProvider'
 
 describe('ThemeProvider', () => {
   test('renders', () => {
@@ -18,5 +18,29 @@ describe('ThemeProvider', () => {
     const json = renderer.create(<Base theme={theme} />).toJSON()
     expect(json).toMatchSnapshot()
     expect(json).toHaveStyleRule('font-family', theme.font)
+  })
+
+  test('pxToEm converts pixel values to em', () => {
+    const em = pxToEm(256)
+    expect(em).toEqual(16)
+  })
+
+  test('accepts a custom breakpoints prop', () => {
+    const json = renderer
+      .create(
+        <ThemeProvider customBreakpoints={[320, 512, 768, 1024]}>
+          <Box width={[1, 1 / 2, 1 / 4]} />
+        </ThemeProvider>
+      )
+      .toJSON()
+    const [box] = json.children
+    expect(json).toMatchSnapshot()
+    expect(box).toHaveStyleRule('width', '100%')
+    expect(box).toHaveStyleRule('width', '50%', {
+      media: 'screen and (min-width:20em)'
+    })
+    expect(box).toHaveStyleRule('width', '25%', {
+      media: 'screen and (min-width:32em)'
+    })
   })
 })

--- a/src/__tests__/__snapshots__/ThemeProvider.js.snap
+++ b/src/__tests__/__snapshots__/ThemeProvider.js.snap
@@ -15,6 +15,48 @@ exports[`ThemeProvider Base component includes a font 1`] = `
 />
 `;
 
+exports[`ThemeProvider accepts a custom breakpoints prop 1`] = `
+.c1 {
+  width: 100%;
+}
+
+.c0 {
+  font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.4;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+@media screen and (min-width:20em) {
+  .c1 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c1 {
+    width: 25%;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+    width={
+      Array [
+        1,
+        0.5,
+        0.25,
+      ]
+    }
+  />
+</div>
+`;
+
 exports[`ThemeProvider renders 1`] = `
 .c0 {
   font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;


### PR DESCRIPTION
In order to allow custom breakpoint value overrides per app, this adds a `customBreakpints` prop to the ThemeProvider.