### PR TITLE
Use fractional max-width values in Hide component - fixes #151

### DIFF
--- a/src/Hide.js
+++ b/src/Hide.js
@@ -3,14 +3,21 @@ import PropTypes from 'prop-types'
 import Box from './Box'
 import theme from './theme'
 
+const getMaxWidth = em => em - 0.01
+
 const breakpoints = props => ({
-  xs: `@media screen and (max-width: ${props.theme.breakpoints[0]}em)`,
-  sm: `@media screen and (min-width: ${props.theme
-    .breakpoints[0]}em) and (max-width: ${props.theme.breakpoints[1]}em)`,
-  md: `@media screen and (min-width: ${props.theme
-    .breakpoints[1]}em) and (max-width: ${props.theme.breakpoints[2]}em)`,
-  lg: `@media screen and (min-width: ${props.theme
-    .breakpoints[2]}em) and (max-width: ${props.theme.breakpoints[3]}em)`,
+  xs: `@media screen and (max-width: ${getMaxWidth(
+    props.theme.breakpoints[0]
+  )}em)`,
+  sm: `@media screen and (min-width: ${
+    props.theme.breakpoints[0]
+  }em) and (max-width: ${getMaxWidth(props.theme.breakpoints[1])}em)`,
+  md: `@media screen and (min-width: ${
+    props.theme.breakpoints[1]
+  }em) and (max-width: ${getMaxWidth(props.theme.breakpoints[2])}em)`,
+  lg: `@media screen and (min-width: ${
+    props.theme.breakpoints[2]
+  }em) and (max-width: ${getMaxWidth(props.theme.breakpoints[3])}em)`,
   xl: `@media screen and (min-width: ${props.theme.breakpoints[3]}em)`
 })
 

--- a/src/__tests__/__snapshots__/Hide.js.snap
+++ b/src/__tests__/__snapshots__/Hide.js.snap
@@ -7,7 +7,7 @@ exports[`Hide renders 1`] = `
 `;
 
 exports[`Hide renders with lg prop 1`] = `
-@media screen and (min-width:48em) and (max-width:64em) {
+@media screen and (min-width:48em) and (max-width:63.99em) {
   .c0 {
     display: none;
   }
@@ -19,7 +19,7 @@ exports[`Hide renders with lg prop 1`] = `
 `;
 
 exports[`Hide renders with md prop 1`] = `
-@media screen and (min-width:40em) and (max-width:48em) {
+@media screen and (min-width:40em) and (max-width:47.99em) {
   .c0 {
     display: none;
   }
@@ -31,7 +31,7 @@ exports[`Hide renders with md prop 1`] = `
 `;
 
 exports[`Hide renders with sm prop 1`] = `
-@media screen and (min-width:32em) and (max-width:40em) {
+@media screen and (min-width:32em) and (max-width:39.99em) {
   .c0 {
     display: none;
   }
@@ -55,7 +55,7 @@ exports[`Hide renders with xl prop 1`] = `
 `;
 
 exports[`Hide renders with xs prop 1`] = `
-@media screen and (max-width:32em) {
+@media screen and (max-width:31.99em) {
   .c0 {
     display: none;
   }


### PR DESCRIPTION
Currently, there is a gap between breakpoints in the Hide component, which means at specific viewport widths, both `xs` and `sm` will be set to `display: none`. Generally, I'd advise against using the Hide component to show different elements *across* breakpoints, but this fix allows you do to so.