### PR TITLE
Add font-family: inherit to pull in Montserrat

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "enzyme-adapter-react-15": "^1.0.2",
     "husky": "^0.14.3",
     "jest": "^20.0.4",
-    "jest-styled-components": "^4.9.0",
+    "jest-styled-components": "^4.7.1",
     "lint-staged": "^4.2.3",
     "prettier": "^1.7.4",
     "react": "^15.6.1",

--- a/src/Button.js
+++ b/src/Button.js
@@ -40,6 +40,7 @@ const Button = styled.button`
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: ${props => props.theme.radius};

--- a/src/__tests__/__snapshots__/Button.js.snap
+++ b/src/__tests__/__snapshots__/Button.js.snap
@@ -7,6 +7,7 @@ exports[`Button disabled prop sets 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;
@@ -36,6 +37,7 @@ exports[`Button fullWidth prop sets width to 100% 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;
@@ -69,6 +71,7 @@ exports[`Button renders 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;
@@ -101,6 +104,7 @@ exports[`Button size large sets height and font-size 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;
@@ -134,6 +138,7 @@ exports[`Button size medium sets height and font-size 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;
@@ -167,6 +172,7 @@ exports[`Button size small sets height and font-size 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;
@@ -200,6 +206,7 @@ exports[`Button without disabled prop sets 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;

--- a/src/__tests__/__snapshots__/CloseButton.js.snap
+++ b/src/__tests__/__snapshots__/CloseButton.js.snap
@@ -13,6 +13,7 @@ exports[`CloseButton renders without props 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;

--- a/src/__tests__/__snapshots__/GreenButton.js.snap
+++ b/src/__tests__/__snapshots__/GreenButton.js.snap
@@ -7,6 +7,7 @@ exports[`GreenButton disabled prop sets 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;
@@ -40,6 +41,7 @@ exports[`GreenButton renders 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;
@@ -80,6 +82,7 @@ exports[`GreenButton without disabled prop sets 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;

--- a/src/__tests__/__snapshots__/IconButton.js.snap
+++ b/src/__tests__/__snapshots__/IconButton.js.snap
@@ -13,6 +13,7 @@ exports[`IconButton renders without props 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;

--- a/src/__tests__/__snapshots__/OutlineButton.js.snap
+++ b/src/__tests__/__snapshots__/OutlineButton.js.snap
@@ -7,6 +7,7 @@ exports[`OutlineButton disabled prop sets 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;
@@ -48,6 +49,7 @@ exports[`OutlineButton renders 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;
@@ -94,6 +96,7 @@ exports[`OutlineButton without disabled prop sets 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;

--- a/src/__tests__/__snapshots__/RedButton.js.snap
+++ b/src/__tests__/__snapshots__/RedButton.js.snap
@@ -7,6 +7,7 @@ exports[`RedButton disabled prop sets 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;
@@ -40,6 +41,7 @@ exports[`RedButton renders 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;
@@ -80,6 +82,7 @@ exports[`RedButton without disabled prop sets 1`] = `
   vertical-align: middle;
   text-align: center;
   text-decoration: none;
+  font-family: inherit;
   font-weight: 600;
   cursor: pointer;
   border-radius: 2px;


### PR DESCRIPTION
I noticed buttons weren't pulling in Montserrat. Adding `font-family: inherit` seemed to fix it. 