### PR TITLE
#163 add children rendering to banner

### DIFF
--- a/.storybook/Banner.js
+++ b/.storybook/Banner.js
@@ -657,14 +657,7 @@ storiesOf('Banner', module)
   ))
   .add('With custom icons and sizes', () => (
     <Box>
-      <Banner
-        textAlign="right"
-        mb={2}
-        p={2}
-        text="default"
-        iconName="star"
-        iconSize={10}
-      />
+      <Banner textAlign="right" mb={2} p={2} text="default" iconName="star" />
       <Banner
         textAlign="left"
         mb={2}
@@ -672,7 +665,6 @@ storiesOf('Banner', module)
         text="blue"
         bg="blue"
         iconName="star"
-        iconSize={12}
       />
       <Banner
         textAlign="right"
@@ -681,7 +673,6 @@ storiesOf('Banner', module)
         text="green"
         bg="green"
         iconName="star"
-        iconSize={14}
       />
       <Banner
         textAlign="left"
@@ -690,7 +681,6 @@ storiesOf('Banner', module)
         text="orange"
         bg="orange"
         iconName="star"
-        iconSize={16}
       />
       <Banner
         textAlign="right"
@@ -699,7 +689,6 @@ storiesOf('Banner', module)
         text="red"
         bg="red"
         iconName="star"
-        iconSize={18}
       />
       <Banner
         textAlign="left"
@@ -708,7 +697,6 @@ storiesOf('Banner', module)
         text="blue"
         bg="lightBlue"
         iconName="star"
-        iconSize={20}
       />
       <Banner
         textAlign="right"
@@ -717,7 +705,6 @@ storiesOf('Banner', module)
         text="green"
         bg="lightGreen"
         iconName="star"
-        iconSize={22}
       />
       <Banner
         textAlign="left"
@@ -726,7 +713,6 @@ storiesOf('Banner', module)
         text="orange"
         bg="lightOrange"
         iconName="star"
-        iconSize={24}
       />
       <Banner
         textAlign="right"
@@ -735,7 +721,6 @@ storiesOf('Banner', module)
         text="red"
         bg="lightRed"
         iconName="star"
-        iconSize={26}
       />
     </Box>
   ))

--- a/.storybook/Banner.js
+++ b/.storybook/Banner.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf, action } from '@storybook/react'
-import { Box, Banner } from '../src'
+import { Box, Banner, Flex, Text } from '../src'
 
 storiesOf('Banner', module)
   .add('All bgs', () => (
@@ -737,5 +737,30 @@ storiesOf('Banner', module)
         iconName="star"
         iconSize={26}
       />
+    </Box>
+  ))
+  .add('With children', () => (
+    <Box>
+      <Banner p={2} mb={2} onClose={action('closed')}>
+        <Flex>
+          <Box bg={'pink'} p={2} width={1 / 2}>
+            Pink box!
+          </Box>
+          <Box bg={'red'} p={2} width={1 / 2}>
+            Red box!
+          </Box>
+        </Flex>
+      </Banner>
+      <Banner
+        textAlign="left"
+        mb={2}
+        p={2}
+        header="default"
+        onClose={action('closed')}
+      >
+        <Text bold italic>
+          I am a text component!
+        </Text>
+      </Banner>
     </Box>
   ))

--- a/docs/Banner.md
+++ b/docs/Banner.md
@@ -7,7 +7,6 @@ Use `<Banner />` component to create a box with a optional header, text, optiona
   bg='green'
   header='Banner'
   iconName='star'
-  iconSize={20}
   text='This is a banner'
   onClose={() => {}}
   showIcon='false'
@@ -24,7 +23,6 @@ Prop | Type | Description
 bg | string | Sets background-color and color. Accepts `blue`, `green`, `orange`, `red`, `lightBlue`, `lightGreen`, `lightOrange`, `lightRed`
 header | string | Sets header content
 iconName | string | Sets left-hand svg icon name
-iconSize | number | Sets left-hand svg icon size
 onClose | function | passes onClick functionality to close button / shows close button if provided
 showIcon | boolean | Renders left-hand icon (true by default)
 text | string | Sets text content

--- a/docs/Banner.md
+++ b/docs/Banner.md
@@ -13,6 +13,10 @@ Use `<Banner />` component to create a box with a optional header, text, optiona
   showIcon='false'
   textAlign='right'
 />
+
+<Banner>
+  This banner is rendering children instead of the text prop
+</Banner>
 ```
 
 Prop | Type | Description

--- a/src/Banner.js
+++ b/src/Banner.js
@@ -15,7 +15,7 @@ const bannerColors = {
   },
   lightGreen: {
     backgroundColor: 'lightGreen',
-    color: 'text',
+    color: 'darkGreen',
     icon: 'success'
   },
   red: {
@@ -25,7 +25,7 @@ const bannerColors = {
   },
   lightRed: {
     backgroundColor: 'lightRed',
-    color: 'text',
+    color: 'darkRed',
     icon: 'warning'
   },
   orange: {
@@ -35,7 +35,7 @@ const bannerColors = {
   },
   lightOrange: {
     backgroundColor: 'lightOrange',
-    color: 'text',
+    color: 'darkOrange',
     icon: 'attention'
   },
   blue: {
@@ -45,7 +45,7 @@ const bannerColors = {
   },
   lightBlue: {
     backgroundColor: 'lightBlue',
-    color: 'text',
+    color: 'darkBlue',
     icon: 'information'
   }
 }

--- a/src/Banner.js
+++ b/src/Banner.js
@@ -62,6 +62,7 @@ const Banner = props => {
         <Box width={1} align={props.textAlign}>
           <Heading.h5>{props.header}</Heading.h5>
           <Text.span fontSize={1}>{props.text}</Text.span>
+          {props.children}
         </Box>
         {!!props.onClose && (
           <CloseButton
@@ -84,7 +85,7 @@ Banner.propTypes = {
   iconName: PropTypes.string,
   onClose: PropTypes.func,
   showIcon: PropTypes.bool,
-  text: PropTypes.string.isRequired,
+  text: PropTypes.string,
   textAlign: PropTypes.string
 }
 

--- a/src/__tests__/Banner.js
+++ b/src/__tests__/Banner.js
@@ -132,4 +132,15 @@ describe('Banner', () => {
     expect(json).toMatchSnapshot()
     expect(json).not.toHaveStyleRule('background-color', theme.colors.gray)
   })
+
+  test('renders content from children props', () => {
+    const json = renderer
+      .create(
+        <Banner>
+          <span>123</span>
+        </Banner>
+      )
+      .toJSON()
+    expect(json).toMatchSnapshot()
+  })
 })

--- a/src/__tests__/Banner.js
+++ b/src/__tests__/Banner.js
@@ -2,7 +2,7 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { shallow } from 'enzyme'
 import 'jest-styled-components'
-import { Banner, theme } from '..'
+import { Banner, Text, theme } from '..'
 
 describe('Banner', () => {
   test('renders with no props other than theme', () => {
@@ -13,6 +13,36 @@ describe('Banner', () => {
   test('renders with custom iconName and size', () => {
     const json = renderer
       .create(<Banner iconName="star" iconSize={20} />)
+      .toJSON()
+    expect(json).toMatchSnapshot()
+  })
+
+  test('renders with text string', () => {
+    const json = renderer
+      .create(
+        <Banner
+          header="Header"
+          text="Text"
+          iconName="star"
+          iconSize={20}
+          theme={theme}
+        />
+      )
+      .toJSON()
+    expect(json).toMatchSnapshot()
+  })
+
+  test('renders with text node', () => {
+    const json = renderer
+      .create(
+        <Banner
+          header="Header"
+          text={<Text>Text</Text>}
+          iconName="star"
+          iconSize={20}
+          theme={theme}
+        />
+      )
       .toJSON()
     expect(json).toMatchSnapshot()
   })
@@ -49,28 +79,28 @@ describe('Banner', () => {
     const json = renderer.create(<Banner bg="lightBlue" />).toJSON()
     expect(json).toMatchSnapshot()
     expect(json).toHaveStyleRule('background-color', theme.colors.lightBlue)
-    expect(json).toHaveStyleRule('color', theme.colors.text)
+    expect(json).toHaveStyleRule('color', theme.colors.darkBlue)
   })
 
   test('renders with lightGreen bg', () => {
     const json = renderer.create(<Banner bg="lightGreen" />).toJSON()
     expect(json).toMatchSnapshot()
     expect(json).toHaveStyleRule('background-color', theme.colors.lightGreen)
-    expect(json).toHaveStyleRule('color', theme.colors.text)
+    expect(json).toHaveStyleRule('color', theme.colors.darkGreen)
   })
 
   test('renders with lightOrange bg', () => {
     const json = renderer.create(<Banner bg="lightOrange" />).toJSON()
     expect(json).toMatchSnapshot()
     expect(json).toHaveStyleRule('background-color', theme.colors.lightOrange)
-    expect(json).toHaveStyleRule('color', theme.colors.text)
+    expect(json).toHaveStyleRule('color', theme.colors.darkOrange)
   })
 
   test('renders with lightRed bg', () => {
     const json = renderer.create(<Banner bg="lightRed" />).toJSON()
     expect(json).toMatchSnapshot()
     expect(json).toHaveStyleRule('background-color', theme.colors.lightRed)
-    expect(json).toHaveStyleRule('color', theme.colors.text)
+    expect(json).toHaveStyleRule('color', theme.colors.darkRed)
   })
 
   test('renders close button if onClose func is provided', () => {

--- a/src/__tests__/__snapshots__/Banner.js.snap
+++ b/src/__tests__/__snapshots__/Banner.js.snap
@@ -58,6 +58,93 @@ exports[`Banner only accepts preset colors 1`] = `
 </div>
 `;
 
+exports[`Banner renders content from children props 1`] = `
+.c0 {
+  background-color: #0a0;
+  color: #fff;
+}
+
+.c2 {
+  text-align: flex-start;
+}
+
+.c4 {
+  width: 100%;
+  text-align: left;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c6 {
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  margin-right: 32px;
+  margin-top: -2px;
+}
+
+.c5 {
+  font-size: 16px;
+  margin: 0px;
+}
+
+<div
+  className="c0"
+  color="white"
+>
+  <div
+    className="c1 c2"
+  >
+    <svg
+      className="c3"
+      fill="currentcolor"
+      height={24}
+      mr={3}
+      mt="-2px"
+      viewBox="0 0 20 20"
+      width={24}
+    >
+      <path
+        d="M8,15,3,10,4.41,8.59,8,12.17l7.59-7.59L17,6ZM10,0A10,10,0,1,0,20,10,10,10,0,0,0,10,0Z"
+      />
+    </svg>
+    <div
+      className="c4"
+      width={1}
+    >
+      <h5
+        className="c5"
+        fontSize={2}
+      />
+      <span
+        className="c6"
+        fontSize={1}
+      />
+      <span>
+        123
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Banner renders with blue bg 1`] = `
 .c2 {
   text-align: flex-start;

--- a/src/__tests__/__snapshots__/Banner.js.snap
+++ b/src/__tests__/__snapshots__/Banner.js.snap
@@ -409,7 +409,7 @@ exports[`Banner renders with lightBlue bg 1`] = `
 
 .c0 {
   background-color: #cdf;
-  color: #001833;
+  color: #049;
 }
 
 .c1 {
@@ -446,7 +446,7 @@ exports[`Banner renders with lightBlue bg 1`] = `
 
 <div
   className="c0"
-  color="text"
+  color="darkBlue"
 >
   <div
     className="c1 c2"
@@ -493,7 +493,7 @@ exports[`Banner renders with lightGreen bg 1`] = `
 
 .c0 {
   background-color: #cec;
-  color: #001833;
+  color: #060;
 }
 
 .c1 {
@@ -530,7 +530,7 @@ exports[`Banner renders with lightGreen bg 1`] = `
 
 <div
   className="c0"
-  color="text"
+  color="darkGreen"
 >
   <div
     className="c1 c2"
@@ -577,7 +577,7 @@ exports[`Banner renders with lightOrange bg 1`] = `
 
 .c0 {
   background-color: #fec;
-  color: #001833;
+  color: #950;
 }
 
 .c1 {
@@ -614,7 +614,7 @@ exports[`Banner renders with lightOrange bg 1`] = `
 
 <div
   className="c0"
-  color="text"
+  color="darkOrange"
 >
   <div
     className="c1 c2"
@@ -661,7 +661,7 @@ exports[`Banner renders with lightRed bg 1`] = `
 
 .c0 {
   background-color: #fcc;
-  color: #001833;
+  color: #800;
 }
 
 .c1 {
@@ -698,7 +698,7 @@ exports[`Banner renders with lightRed bg 1`] = `
 
 <div
   className="c0"
-  color="text"
+  color="darkRed"
 >
   <div
     className="c1 c2"
@@ -980,6 +980,186 @@ exports[`Banner renders with red bg 1`] = `
         className="c6"
         fontSize={1}
       />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Banner renders with text node 1`] = `
+.c0 {
+  background-color: #0a0;
+  color: #fff;
+}
+
+.c2 {
+  text-align: flex-start;
+}
+
+.c4 {
+  width: 100%;
+  text-align: left;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c6 {
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  margin-right: 32px;
+  margin-top: -2px;
+}
+
+.c5 {
+  font-size: 16px;
+  margin: 0px;
+}
+
+<div
+  className="c0"
+  color="white"
+>
+  <div
+    className="c1 c2"
+  >
+    <svg
+      className="c3"
+      fill="currentcolor"
+      height={24}
+      mr={3}
+      mt="-2px"
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M12,1.54L14.55,9.6,23,9.53l-6.87,4.91,2.67,8-6.8-5-6.8,5,2.67-8L1,9.53,9.45,9.6Z"
+      />
+    </svg>
+    <div
+      className="c4"
+      width={1}
+    >
+      <h5
+        className="c5"
+        fontSize={2}
+      >
+        Header
+      </h5>
+      <span
+        className="c6"
+        fontSize={1}
+      >
+        <div
+          className=""
+        >
+          Text
+        </div>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Banner renders with text string 1`] = `
+.c0 {
+  background-color: #0a0;
+  color: #fff;
+}
+
+.c2 {
+  text-align: flex-start;
+}
+
+.c4 {
+  width: 100%;
+  text-align: left;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c6 {
+  font-size: 14px;
+}
+
+.c3 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  margin-right: 32px;
+  margin-top: -2px;
+}
+
+.c5 {
+  font-size: 16px;
+  margin: 0px;
+}
+
+<div
+  className="c0"
+  color="white"
+>
+  <div
+    className="c1 c2"
+  >
+    <svg
+      className="c3"
+      fill="currentcolor"
+      height={24}
+      mr={3}
+      mt="-2px"
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M12,1.54L14.55,9.6,23,9.53l-6.87,4.91,2.67,8-6.8-5-6.8,5,2.67-8L1,9.53,9.45,9.6Z"
+      />
+    </svg>
+    <div
+      className="c4"
+      width={1}
+    >
+      <h5
+        className="c5"
+        fontSize={2}
+      >
+        Header
+      </h5>
+      <span
+        className="c6"
+        fontSize={1}
+      >
+        Text
+      </span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Wanted to be able to render html / other design system components inside a banner instead of just passing in text. Didn't remove any functionality, only added.

before: `<Banner text='Lorem ipsum' />`
after: `<Banner> **go crazy** </Banner>`

![image](https://user-images.githubusercontent.com/1365995/33489838-20d1cd98-d683-11e7-8059-cfdac344559d.png)
