### PR TITLE
bugfix(InputField): add default margins to InputField

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -34,6 +34,8 @@ const Input = styled.input`
   padding-left: 12px;
   padding-right: 12px;
 
+  margin: 0;
+
   ::placeholder {
     color: ${theme('colors.gray')};
   }

--- a/src/InputField.js
+++ b/src/InputField.js
@@ -114,7 +114,7 @@ class InputField extends React.Component {
         {showLabel &&
           React.cloneElement(LabelChild, {
             pl: BeforeIcon ? 40 : 2,
-            mt: '6px',
+            mt: '5px',
             style: labelStyles,
             htmlFor: inputId
           })}

--- a/src/Label.js
+++ b/src/Label.js
@@ -7,6 +7,7 @@ const Label = styled.label`
   letter-spacing: 0.2px;
   display: block;
   width: 100%;
+  margin: 0;
 
   ${space} ${fontSize} ${color} ${fontWeight};
 `

--- a/src/__tests__/__snapshots__/Input.js.snap
+++ b/src/__tests__/__snapshots__/Input.js.snap
@@ -18,6 +18,7 @@ exports[`Input it renders 1`] = `
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
+  margin: 0;
   border-color: #d1d6db;
   box-shadow: 0 0 0 0 #d1d6db;
 }
@@ -71,6 +72,7 @@ exports[`Input it renders an input element with a really large padding and margi
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
+  margin: 0;
   border-color: #d1d6db;
   box-shadow: 0 0 0 0 #d1d6db;
   margin: 32px;
@@ -126,6 +128,7 @@ exports[`Input it renders an input element with a red border with a color prop i
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
+  margin: 0;
   border-color: #c00;
   box-shadow: 0 0 0 0 #c00;
 }
@@ -180,6 +183,7 @@ exports[`Input it renders an input element with large text 1`] = `
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
+  margin: 0;
   border-color: #d1d6db;
   box-shadow: 0 0 0 0 #d1d6db;
 }

--- a/src/__tests__/__snapshots__/InputField.js.snap
+++ b/src/__tests__/__snapshots__/InputField.js.snap
@@ -48,6 +48,7 @@ exports[`InputField it renders a form field wth a label and icons 1`] = `
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
+  margin: 0;
   border-color: #d1d6db;
   box-shadow: 0 0 0 0 #d1d6db;
   padding-left: 40px;
@@ -185,6 +186,7 @@ exports[`InputField it renders a with a both icons 1`] = `
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
+  margin: 0;
   border-color: #d1d6db;
   box-shadow: 0 0 0 0 #d1d6db;
   padding-left: 40px;
@@ -305,6 +307,7 @@ exports[`InputField it renders a with a conditional right side icon 1`] = `
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
+  margin: 0;
   border-color: #d1d6db;
   box-shadow: 0 0 0 0 #d1d6db;
   padding-left: 8px;
@@ -404,6 +407,7 @@ exports[`InputField it renders a with a left side icon 1`] = `
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
+  margin: 0;
   border-color: #d1d6db;
   box-shadow: 0 0 0 0 #d1d6db;
   padding-left: 40px;
@@ -518,6 +522,7 @@ exports[`InputField it renders a with a right side icon 1`] = `
   padding-bottom: 14px;
   padding-left: 12px;
   padding-right: 12px;
+  margin: 0;
   border-color: #d1d6db;
   box-shadow: 0 0 0 0 #d1d6db;
   padding-left: 8px;

--- a/src/__tests__/__snapshots__/Label.js.snap
+++ b/src/__tests__/__snapshots__/Label.js.snap
@@ -9,6 +9,7 @@ exports[`Label it renders 1`] = `
   letter-spacing: 0.2px;
   display: block;
   width: 100%;
+  margin: 0;
   font-size: 10px;
   color: #687B8E;
   font-weight: 600;


### PR DESCRIPTION
I noticed when trying to use an InputField that global `input` styles for margin in a host app were causing the margins to be incorrect. 
![margin-issue](https://user-images.githubusercontent.com/1385339/35354684-d1bd3e0c-0118-11e8-8a9b-c638b0aeb6e5.gif)

So modified the code so that if "showLabel" evaluates to false I set some default margins instead of only applying a margin when it's true.