### PR TITLE
fix(InputField): Make positioning of Label account for border around …

### DIFF
--- a/src/InputField.js
+++ b/src/InputField.js
@@ -19,7 +19,8 @@ const fadeIn = keyframes`
   }
 `
 const labelStyles = {
-  animation: fadeIn + ' 0.3s'
+  animation: fadeIn + ' 0.3s',
+  border: '1px solid transparent'
 }
 
 const getInputStyles = showLabel => {


### PR DESCRIPTION
…the InputField

Not sure how this wasn't noticed before, but since input field has a border, the content of it is shifted over 1 px to the right. The Label has no border and the padding did not account for the border, so it looks too far left. This adds a transparent left border to the Label.

The alternative is to add a pixel of padding-left to the Label.

Before:
![image](https://user-images.githubusercontent.com/1385339/35685623-39f91e94-0738-11e8-9e54-a1c6d11c3810.png)

After:
![image](https://user-images.githubusercontent.com/1385339/35685655-4b27df34-0738-11e8-9223-c102845f4834.png)
