### PR TITLE
Add optional Label styles

### DIFF
--- a/.storybook/Label.js
+++ b/.storybook/Label.js
@@ -50,17 +50,17 @@ storiesOf('Label', module)
   ))
   .add('nowrap', () => (
     <Flex>
-      <Label.nowrap>
+      <Label nowrap>
         <Radio checked />
         Round-trip
-      </Label.nowrap>
-      <Label.nowrap>
+      </Label>
+      <Label nowrap>
         <Radio checked />
         One-way
-      </Label.nowrap>
-      <Label.nowrap>
+      </Label>
+      <Label nowrap>
         <Radio checked />
         Multi-destination
-      </Label.nowrap>
+      </Label>
     </Flex>
   ))

--- a/.storybook/Label.js
+++ b/.storybook/Label.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
-import { Label, Input } from '../src'
+import { Label, Input, Radio, Flex } from '../src'
 
 storiesOf('Label', module)
   .add(
@@ -47,4 +47,20 @@ storiesOf('Label', module)
       <br />
       <Input id="sample-input" />
     </div>
+  ))
+  .add('nowrap', () => (
+    <Flex>
+      <Label.nowrap>
+        <Radio checked />
+        Round-trip
+      </Label.nowrap>
+      <Label.nowrap>
+        <Radio checked />
+        One-way
+      </Label.nowrap>
+      <Label.nowrap>
+        <Radio checked />
+        Multi-destination
+      </Label.nowrap>
+    </Flex>
   ))

--- a/docs/Label.md
+++ b/docs/Label.md
@@ -1,0 +1,28 @@
+# Label
+
+Styled form `<label>` element.
+
+```jsx
+<Label htmlFor='email'>Email</Label>
+<Input
+  id='email'
+  name='email'
+/>
+```
+
+```jsx
+// Use Label.hidden to visually hide a label
+// NOTE: this WILL cause accessibility and usability issues
+<Label.hidden htmlFor='email'>Email</Label.hidden>
+<Input
+  id='email'
+  name='email'
+/>
+```
+
+```jsx
+<Label.nowrap>
+  <Radio />
+  This label will not wrap
+</Label.nowrap>
+```

--- a/docs/Label.md
+++ b/docs/Label.md
@@ -11,18 +11,27 @@ Styled form `<label>` element.
 ```
 
 ```jsx
-// Use Label.hidden to visually hide a label
-// NOTE: this WILL cause accessibility and usability issues
-<Label.hidden htmlFor='email'>Email</Label.hidden>
+<Label nowrap>
+  <Radio />
+  This label will not wrap
+</Label>
+```
+
+To hide a form label but still allow screen readers to announce the element, use the `hidden` prop.
+
+This **can still cause accessiblity issues** if there isn't an alternative, visible label for people to read visually.
+The `placeholder` attribute **is not** a replacement for a label.
+
+See the following for more info:
+
+- [How-to: Use Placeholder Attributes](https://a11yproject.com/posts/placeholder-input-elements/)
+- [How-to: Hide Content](https://a11yproject.com/posts/how-to-hide-content/)
+
+```jsx
+<Label hidden htmlFor='email'>Email</Label>
 <Input
   id='email'
   name='email'
 />
 ```
 
-```jsx
-<Label.nowrap>
-  <Radio />
-  This label will not wrap
-</Label.nowrap>
-```

--- a/src/Label.js
+++ b/src/Label.js
@@ -2,6 +2,21 @@ import styled from 'styled-components'
 import { space, fontSize, fontWeight, color, propTypes } from 'styled-system'
 import theme from './theme'
 
+const nowrap = props =>
+  props.nowrap
+    ? {
+        whiteSpace: 'nowrap'
+      }
+    : null
+
+const accessiblyHide = props =>
+  props.hidden
+    ? {
+        position: 'absolute',
+        clip: 'rect(1px, 1px, 1px, 1px)'
+      }
+    : null
+
 const Label = styled.label`
   font-size: 10px;
   letter-spacing: 0.2px;
@@ -10,6 +25,8 @@ const Label = styled.label`
   margin: 0;
 
   ${space} ${fontSize} ${color} ${fontWeight};
+  ${nowrap}
+  ${accessiblyHide}
 `
 
 Label.propTypes = {
@@ -27,14 +44,5 @@ Label.defaultProps = {
 }
 
 Label.displayName = 'Label'
-
-Label.nowrap = Label.extend`
-  white-space: nowrap;
-`
-
-Label.hidden = Label.extend`
-  position: absolute;
-  clip: rect(1px, 1px, 1px, 1px);
-`
 
 export default Label

--- a/src/Label.js
+++ b/src/Label.js
@@ -28,4 +28,13 @@ Label.defaultProps = {
 
 Label.displayName = 'Label'
 
+Label.nowrap = Label.extend`
+  white-space: nowrap;
+`
+
+Label.hidden = Label.extend`
+  position: absolute;
+  clip: rect(1px, 1px, 1px, 1px);
+`
+
 export default Label

--- a/src/__tests__/Label.js
+++ b/src/__tests__/Label.js
@@ -7,4 +7,14 @@ describe('Label', () => {
     const json = renderer.create(<Label />).toJSON()
     expect(json).toMatchSnapshot()
   })
+
+  test('Label.hidden renders', () => {
+    const json = renderer.create(<Label.hidden />).toJSON()
+    expect(json).toMatchSnapshot()
+  })
+
+  test('Label.nowrap renders', () => {
+    const json = renderer.create(<Label.nowrap />).toJSON()
+    expect(json).toMatchSnapshot()
+  })
 })

--- a/src/__tests__/Label.js
+++ b/src/__tests__/Label.js
@@ -8,13 +8,13 @@ describe('Label', () => {
     expect(json).toMatchSnapshot()
   })
 
-  test('Label.hidden renders', () => {
-    const json = renderer.create(<Label.hidden />).toJSON()
+  test('Label hidden renders', () => {
+    const json = renderer.create(<Label hidden />).toJSON()
     expect(json).toMatchSnapshot()
   })
 
-  test('Label.nowrap renders', () => {
-    const json = renderer.create(<Label.nowrap />).toJSON()
+  test('Label nowrap renders', () => {
+    const json = renderer.create(<Label nowrap />).toJSON()
     expect(json).toMatchSnapshot()
   })
 })

--- a/src/__tests__/__snapshots__/Button.js.snap
+++ b/src/__tests__/__snapshots__/Button.js.snap
@@ -6,6 +6,7 @@ exports[`Button disabled prop sets 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
@@ -36,6 +37,7 @@ exports[`Button fullWidth prop sets width to 100% 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
@@ -70,6 +72,7 @@ exports[`Button renders 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
@@ -103,6 +106,7 @@ exports[`Button size large sets height and font-size 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
@@ -137,6 +141,7 @@ exports[`Button size medium sets height and font-size 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
@@ -171,6 +176,7 @@ exports[`Button size small sets height and font-size 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
@@ -205,6 +211,7 @@ exports[`Button without disabled prop sets 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;

--- a/src/__tests__/__snapshots__/CloseButton.js.snap
+++ b/src/__tests__/__snapshots__/CloseButton.js.snap
@@ -12,6 +12,7 @@ exports[`CloseButton renders without props 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;

--- a/src/__tests__/__snapshots__/GreenButton.js.snap
+++ b/src/__tests__/__snapshots__/GreenButton.js.snap
@@ -6,6 +6,7 @@ exports[`GreenButton disabled prop sets 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
@@ -40,6 +41,7 @@ exports[`GreenButton renders 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
@@ -81,6 +83,7 @@ exports[`GreenButton without disabled prop sets 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;

--- a/src/__tests__/__snapshots__/IconButton.js.snap
+++ b/src/__tests__/__snapshots__/IconButton.js.snap
@@ -12,6 +12,7 @@ exports[`IconButton renders without props 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;

--- a/src/__tests__/__snapshots__/Label.js.snap
+++ b/src/__tests__/__snapshots__/Label.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Label Label.hidden renders 1`] = `
+exports[`Label Label hidden renders 1`] = `
 .c0 {
   font-size: 10px;
   -webkit-letter-spacing: 0.2px;
@@ -23,10 +23,11 @@ exports[`Label Label.hidden renders 1`] = `
   color="gray"
   fontSize="10px"
   fontWeight="bold"
+  hidden={true}
 />
 `;
 
-exports[`Label Label.nowrap renders 1`] = `
+exports[`Label Label nowrap renders 1`] = `
 .c0 {
   font-size: 10px;
   -webkit-letter-spacing: 0.2px;

--- a/src/__tests__/__snapshots__/Label.js.snap
+++ b/src/__tests__/__snapshots__/Label.js.snap
@@ -1,5 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Label Label.hidden renders 1`] = `
+.c0 {
+  font-size: 10px;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
+  display: block;
+  width: 100%;
+  margin: 0;
+  font-size: 10px;
+  color: #687B8E;
+  font-weight: 600;
+  position: absolute;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+}
+
+<label
+  className="c0"
+  color="gray"
+  fontSize="10px"
+  fontWeight="bold"
+/>
+`;
+
+exports[`Label Label.nowrap renders 1`] = `
+.c0 {
+  font-size: 10px;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
+  display: block;
+  width: 100%;
+  margin: 0;
+  font-size: 10px;
+  color: #687B8E;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+<label
+  className="c0"
+  color="gray"
+  fontSize="10px"
+  fontWeight="bold"
+/>
+`;
+
 exports[`Label it renders 1`] = `
 .c0 {
   font-size: 10px;

--- a/src/__tests__/__snapshots__/Link.js.snap
+++ b/src/__tests__/__snapshots__/Link.js.snap
@@ -3,11 +3,13 @@
 exports[`Link renders 1`] = `
 .c0 {
   cursor: pointer;
+  -webkit-text-decoration: none;
   text-decoration: none;
   color: #007aff;
 }
 
 .c0:hover {
+  -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 

--- a/src/__tests__/__snapshots__/OutlineButton.js.snap
+++ b/src/__tests__/__snapshots__/OutlineButton.js.snap
@@ -6,6 +6,7 @@ exports[`OutlineButton disabled prop sets 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
@@ -48,6 +49,7 @@ exports[`OutlineButton renders 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
@@ -95,6 +97,7 @@ exports[`OutlineButton without disabled prop sets 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;

--- a/src/__tests__/__snapshots__/RedButton.js.snap
+++ b/src/__tests__/__snapshots__/RedButton.js.snap
@@ -6,6 +6,7 @@ exports[`RedButton disabled prop sets 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
@@ -40,6 +41,7 @@ exports[`RedButton renders 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
@@ -81,6 +83,7 @@ exports[`RedButton without disabled prop sets 1`] = `
   display: inline-block;
   vertical-align: middle;
   text-align: center;
+  -webkit-text-decoration: none;
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;


### PR DESCRIPTION
- `white-space: nowrap` can be useful when used for radios and checkboxes
- The hidden styles aren't great accessibility wise, but better to have a label element than not at all