### PR TITLE
docs(InputField): add example for error handling

### DIFF
--- a/docs/InputField.md
+++ b/docs/InputField.md
@@ -20,6 +20,52 @@ Make sure to provide an `id` prop to this component, otherwise you will run into
 ### `<Icon />`
 One `<Icon />` can go _before_, and one `<Icon />` can go _after_ the `<Input />` component. Anything else will result in a prop-type warning.
 
+## Error Handling
+All error handling should be performed by the parent component. An example of how one might accomplish this is below.
+
+```jsx
+<Box
+  width={'50%'}
+  bg='white'
+>
+  <InputField onChange={this.props.onChange}>
+    <Icon name='search' color='blue' size={18} />
+    <Input
+      id='some-input'
+      autoComplete='off'
+      color={this.props.errorMessage ? 'red' : null}
+      placeholder='Placeholder text'
+      label='Some Input Field'
+      hasError={!!this.props.errorMessage}
+      aria-describedby={
+        this.props.errorMessage && this.props.isUsingErrorMessage
+          ? 'some-input-error'
+          : null
+      }
+      aria-invalid={!!this.props.errorMessage}
+      maxLength={60}
+      value={this.state.typeAheadContent}
+      onChange={this.handleInputChange}
+      onKeyDown={this.handleInputKeyDown}
+      onClick={this.handleInputClick}
+    />
+    {this.props.errorMessage && <Icon name='warning' color='red' size={20} />}
+  </InputField>
+  {this.props.errorMessage &&
+    <Tooltip
+      id='some-input-error'
+      bottom
+      right
+      color='white'
+      bg='red'
+    >
+      {this.props.errorMessage}
+    </Tooltip>
+  }
+</Box>
+
+```
+
 ### Legacy Support
 This component can also be used in the form:
 ```jsx


### PR DESCRIPTION
This adds some documentation for how to implement error handling with the InputField and Tooltip components inside the InputField documentation.