### PR TITLE
Add npm version badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 
 [![Build Status][travis-badge]][travis]
 [![Coverage][coverage-badge]][coverage]
+[![npm version][npm version]][npm version]
 
 [travis-badge]: https://img.shields.io/travis/pricelinelabs/design-system/master.svg?style=flat-square
 [travis]: https://travis-ci.org/pricelinelabs/design-system
 [coverage-badge]: https://img.shields.io/codecov/c/github/pricelinelabs/design-system.svg?style=flat-square
 [coverage]: https://codecov.io/github/pricelinelabs/design-system
+[npm version]: https://badge.fury.io/js/pcln-design-system.svg
 
 https://pricelinelabs.github.io/design-system/
 


### PR DESCRIPTION
Nice to have:
![image](https://user-images.githubusercontent.com/1974993/36276022-93dd3044-125a-11e8-8c6c-3e054d35d32e.png)
