### PR TITLE
Adds Chromatic regression tests

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import 'react-chromatic/storybook-addon'
 import { configure, addDecorator } from '@storybook/react'
 import { injectGlobal } from 'styled-components'
 import { ThemeProvider, Box } from '../src'
@@ -15,9 +16,7 @@ injectGlobal([], {
 
 addDecorator(story => (
   <ThemeProvider>
-    <Box p={3}>
-      {story()}
-    </Box>
+    <Box p={3}>{story()}</Box>
   </ThemeProvider>
 ))
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "coverage": "jest --coverage",
     "codecov": "jest && codecov",
     "standard": "standard",
-    "test": "jest"
+    "test": "jest",
+    "chromatic": "chromatic test --storybook-addon  --script-name start --app-code=\"uf9gdg938po\""
   },
   "author": "Brent Jackson",
   "contributors": [
@@ -59,6 +60,7 @@
     "lint-staged": "^4.2.3",
     "prettier": "^1.7.4",
     "react": "^15.6.1",
+    "react-chromatic": "^0.7.9",
     "react-dom": "^15.6.1",
     "react-test-renderer": "^15.6.1",
     "standard": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lint-staged": "^4.2.3",
     "prettier": "^1.7.4",
     "react": "^15.6.1",
-    "react-chromatic": "^0.7.9",
+    "react-chromatic": "^0.7.10",
     "react-dom": "^15.6.1",
     "react-test-renderer": "^15.6.1",
     "standard": "^10.0.2",


### PR DESCRIPTION
Hi,

I’m one of the founders at [Chromatic](http://chromaticqa.com), a visual regression testing tool. We’ve been using Priceline's design system as a test case for Chromatic itself (we really like your design aesthetic too).  

As a token of our appreciation, I’d like to offer the design system team Chromatic for free. We’ll also give you hands on support to make sure you have a smooth ride and can get the most out of the tool without taking up much of your time. I've made a small PR that adds visual regression tests. 

We showed Chromatic to @hakimelek late last year and his response was that it looked promising but we dropped the ball on following up. We've made a bunch of improvements since then too.

Chromatic will quickly and easily let you review any visual changes introduced by new code -- it’s especially handy for open source projects where it can be time consuming to evaluate PRs being opened out of the blue by unknown authors.

I’ve already run Chromatic on your design system to establish a baseline for future tests (you can view the results [here](https://www.chromaticqa.com/builds?appId=5a85e56213417800200978ab)). You can run additional tests anytime by calling `npm chromatic`. You could try running `npm chromatic` in this branch after changing a component to see an example of the review flow.

Chromatic really shines when you run the above command from within your CI system as it will then tag PRs with the result of the regression tests, like in the image below.

<img width="808" alt="screen shot 2018-02-23 at 4 42 52 pm" src="https://user-images.githubusercontent.com/81672/36623368-d725b786-18b8-11e8-83a3-d63bc19ded1e.png">

Let me know if you have any questions, once this PR is merged I can help get chromatic running in your CI builds too if you'd like.