### PR TITLE
feat(tooltip) Add optional prop of width to allow for sizing the 'content' element

### DIFF
--- a/.storybook/Tooltip.js
+++ b/.storybook/Tooltip.js
@@ -1,10 +1,13 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Tooltip, InputField, Box, Flex } from '../src'
+import { Tooltip, InputField, Box, Flex, Banner } from '../src'
 import styled from 'styled-components'
 
 const FlexColumn = styled(Flex)`
   flex-direction: column;
+`
+const loripsum = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quis est, qui non oderit libidinosam, protervam adolescentiam? Sed ego in hoc resisto; Ratio enim nostra consentit, pugnat oratio. Nihil enim hoc differt.
 `
 
 storiesOf('Tooltip', module)
@@ -124,4 +127,90 @@ storiesOf('Tooltip', module)
         />
       </Box>
     </FlexColumn>
+  ))
+  .add('With Width', () => (
+    <Box>
+      <Box width={'600px'} p={2} mt={5} ml={3} mb={'150px'}>
+        <Banner text="Very large tooltip (bottom left) " bg={'orange'} p={3} />
+        <Tooltip
+          bottom
+          left
+          bg="green"
+          color="white"
+          width={['200px', '400px']}
+        >
+          {loripsum}
+        </Tooltip>
+      </Box>
+      <Box width={'600px'} p={2} mt={5} ml={3}>
+        <Tooltip
+          top
+          left
+          bg="black"
+          color="white"
+          width={['200px', '400px', '500px', '600px']}
+        >
+          {loripsum}
+        </Tooltip>
+        <Banner text="Very large tooltip (top left)" bg={'orange'} p={3} />
+      </Box>
+
+      <Box width={'600px'} p={2} mt={5} ml={3} mb={'150px'}>
+        <Banner text="Very large tooltip (bottom right)" bg={'blue'} p={3} />
+        <Tooltip
+          bottom
+          right
+          bg="green"
+          color="white"
+          width={['200px', '400px', '550px']}
+        >
+          {loripsum}
+        </Tooltip>
+      </Box>
+      <Box width={'600px'} p={2} mt={5} ml={3}>
+        <Tooltip
+          top
+          right
+          bg="black"
+          color="white"
+          width={['200px', '400px', '500px']}
+        >
+          {loripsum}
+        </Tooltip>
+        <Banner text="Very large tooltip (top right)" bg={'blue'} p={3} />
+      </Box>
+
+      <Box width={'600px'} p={2} mt={5} ml={3} mb={'150px'}>
+        <Banner
+          text="Very large tooltip (bottom center)"
+          bg={'lightGreen'}
+          p={3}
+        />
+        <Tooltip
+          bottom
+          center
+          bg="green"
+          color="white"
+          width={['200px', '400px', '500px', '510px']}
+        >
+          {loripsum}
+        </Tooltip>
+      </Box>
+      <Box width={'600px'} p={2} mt={5} ml={3}>
+        <Tooltip
+          top
+          center
+          bg="black"
+          color="white"
+          width={['200px', '400px', '500px', '600px']}
+        >
+          {loripsum}
+        </Tooltip>
+        <Banner
+          text="Very large tooltip (top center)"
+          bg={'lightGreen'}
+          p={3}
+        />
+      </Box>
+    </Box>
   ))

--- a/docs/Tooltip.md
+++ b/docs/Tooltip.md
@@ -16,6 +16,7 @@ Use `<Tooltip />` component to create a tooltip positioned around any element.
 ### Props
 Prop | Type | Description
 ---|---|---
+width | number, string, or array | Sets the width of the 'content' element
 children | any (Required) | anything you put inside the tags to render
 bg | string | background color
 color | string | font color
@@ -24,4 +25,3 @@ top | bool | tooltip is above content
 center | bool | centered horizontally
 left | bool | towards the left above/below content
 right | bool | towards the right above/below content
-zIndex | number or String | ( default is auto )

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -59,9 +59,7 @@ const tooltipPosition = props => {
 const tooltipAlign = props => {
   return props.right
     ? { right: 0 }
-    : props.center
-      ? { left: '50%', width: 'auto', transform: 'translateX(-50%)' }
-      : null
+    : props.center ? { left: '50%', transform: 'translateX(-50%)' } : null
 }
 
 const TooltipContent = styled(Box)`
@@ -87,6 +85,11 @@ const TooltipContent = styled(Box)`
     ${arrow} ${arrowPosition} ${arrowAlign} ${arrowShadow};
   }
 `
+const numberStringOrArray = PropTypes.oneOfType([
+  PropTypes.number,
+  PropTypes.string,
+  PropTypes.array
+])
 
 const propTypes = {
   children: PropTypes.any.isRequired,
@@ -97,7 +100,7 @@ const propTypes = {
   center: PropTypes.bool,
   left: PropTypes.bool,
   right: PropTypes.bool,
-  zIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  width: numberStringOrArray
 }
 
 const defaultProps = {
@@ -105,13 +108,12 @@ const defaultProps = {
   color: 'text',
   bg: 'white',
   align: 'right',
-  theme: theme,
-  zIndex: 'auto'
+  theme: theme
 }
 
 const Tooltip = ({ children, ...props }) => {
   return (
-    <div style={{ position: 'relative', zIndex: props.zIndex }}>
+    <div style={{ position: 'relative' }}>
       <TooltipContent p={2} mb={3} mt={2} {...props}>
         {children}
       </TooltipContent>

--- a/src/__tests__/Tooltip.js
+++ b/src/__tests__/Tooltip.js
@@ -70,4 +70,19 @@ describe('Tooltip', () => {
       .toJSON()
     expect(json).toMatchSnapshot()
   })
+  test('bottom right including width', () => {
+    const json = renderer
+      .create(
+        <Tooltip
+          theme={theme}
+          bottom
+          right
+          width={['100px', '200px', '300px', '400px']}
+        >
+          right tooltip
+        </Tooltip>
+      )
+      .toJSON()
+    expect(json).toMatchSnapshot()
+  })
 })

--- a/src/__tests__/__snapshots__/Tooltip.js.snap
+++ b/src/__tests__/__snapshots__/Tooltip.js.snap
@@ -21,7 +21,6 @@ exports[`Tooltip bottom center 1`] = `
   text-align: center;
   top: 0;
   left: 50%;
-  width: auto;
   -webkit-transform: translateX(-50%);
   -ms-transform: translateX(-50%);
   transform: translateX(-50%);
@@ -57,7 +56,6 @@ exports[`Tooltip bottom center 1`] = `
   style={
     Object {
       "position": "relative",
-      "zIndex": "auto",
     }
   }
 >
@@ -122,7 +120,6 @@ exports[`Tooltip bottom left 1`] = `
   style={
     Object {
       "position": "relative",
-      "zIndex": "auto",
     }
   }
 >
@@ -188,13 +185,104 @@ exports[`Tooltip bottom right 1`] = `
   style={
     Object {
       "position": "relative",
-      "zIndex": "auto",
     }
   }
 >
   <div
     className="c0 c1"
     color="text"
+  >
+    right tooltip
+  </div>
+</div>
+`;
+
+exports[`Tooltip bottom right including width 1`] = `
+.c1 {
+  margin-bottom: 16px;
+  margin-top: 8px;
+  padding: 8px;
+  width: 100px;
+  color: #001833;
+  background-color: #fff;
+  text-align: right;
+}
+
+.c0 {
+  display: inline;
+  box-shadow: 0 0 2px 0 rgba(0,0,0,.08),0 2px 8px 0 rgba(0,0,0,.16);
+  font-size: 12px;
+  position: absolute;
+  border-radius: 2px;
+  box-sizing: border-box;
+  background: #fff;
+  text-align: center;
+  top: 0;
+  right: 0;
+}
+
+.c0::after {
+  content: '';
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent #fff #fff;
+  -webkit-transform-origin: 0 0;
+  -ms-transform-origin: 0 0;
+  transform-origin: 0 0;
+  -webkit-transform: rotate(-225deg);
+  -ms-transform: rotate(-225deg);
+  transform: rotate(-225deg);
+  -webkit-transform-origin: 0 0;
+  -ms-transform-origin: 0 0;
+  transform-origin: 0 0;
+  -webkit-transform: rotate(-225deg);
+  -ms-transform: rotate(-225deg);
+  transform: rotate(-225deg);
+  top: 0;
+  right: 16px;
+  margin-right: -10px;
+  box-shadow: -1.41px 1.41px 1px 0 rgba(0,0,0,0.01),-3.66px 3.66px 8px 0 rgba(0,0,0,0.04);
+}
+
+@media screen and (min-width:32em) {
+  .c1 {
+    width: 200px;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c1 {
+    width: 300px;
+  }
+}
+
+@media screen and (min-width:48em) {
+  .c1 {
+    width: 400px;
+  }
+}
+
+<div
+  style={
+    Object {
+      "position": "relative",
+    }
+  }
+>
+  <div
+    className="c0 c1"
+    color="text"
+    width={
+      Array [
+        "100px",
+        "200px",
+        "300px",
+        "400px",
+      ]
+    }
   >
     right tooltip
   </div>
@@ -253,7 +341,6 @@ exports[`Tooltip renders 1`] = `
   style={
     Object {
       "position": "relative",
-      "zIndex": "auto",
     }
   }
 >
@@ -287,7 +374,6 @@ exports[`Tooltip top center 1`] = `
   text-align: center;
   bottom: -8px;
   left: 50%;
-  width: auto;
   -webkit-transform: translateX(-50%);
   -ms-transform: translateX(-50%);
   transform: translateX(-50%);
@@ -323,7 +409,6 @@ exports[`Tooltip top center 1`] = `
   style={
     Object {
       "position": "relative",
-      "zIndex": "auto",
     }
   }
 >
@@ -388,7 +473,6 @@ exports[`Tooltip top left 1`] = `
   style={
     Object {
       "position": "relative",
-      "zIndex": "auto",
     }
   }
 >
@@ -454,7 +538,6 @@ exports[`Tooltip top right 1`] = `
   style={
     Object {
       "position": "relative",
-      "zIndex": "auto",
     }
   }
 >


### PR DESCRIPTION
When tooltip is used with large messages there are no developer assignable media breakpoints allowable. These changes allow the developer to implement breakpoints.