### PR TITLE
fix(InputField): Input's border is now a box shadow

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -8,11 +8,11 @@ const borders = ({ color, theme }) => {
   const focusColor = color ? borderColor : theme.colors.blue
   return {
     'border-color': borderColor,
-    'box-shadow': `0 0 0 0 ${borderColor}`,
+    'box-shadow': `0 0 0 1px ${borderColor}`,
     ':focus': {
       outline: 0,
       'border-color': focusColor,
-      'box-shadow': `0 0 0 1px ${focusColor}`
+      'box-shadow': `0 0 0 2px ${focusColor}`
     }
   }
 }
@@ -25,7 +25,7 @@ const Input = styled.input`
   font-size: ${theme('fontSizes.1')}px;
   background-color: transparent;
   border-radius: ${theme('radius')};
-  border-width: 1px;
+  border-width: 0px;
   border-style: solid;
   border-color: ${theme('colors.borderGray')};
 

--- a/src/InputField.js
+++ b/src/InputField.js
@@ -115,7 +115,7 @@ class InputField extends React.Component {
         {showLabel &&
           React.cloneElement(LabelChild, {
             pl: BeforeIcon ? 40 : 2,
-            mt: '5px',
+            mt: '6px',
             style: labelStyles,
             htmlFor: inputId
           })}

--- a/src/__tests__/__snapshots__/Input.js.snap
+++ b/src/__tests__/__snapshots__/Input.js.snap
@@ -11,7 +11,7 @@ exports[`Input it renders 1`] = `
   font-size: 14px;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 1px;
+  border-width: 0px;
   border-style: solid;
   border-color: #d1d6db;
   padding-top: 14px;
@@ -20,7 +20,7 @@ exports[`Input it renders 1`] = `
   padding-right: 12px;
   margin: 0;
   border-color: #d1d6db;
-  box-shadow: 0 0 0 0 #d1d6db;
+  box-shadow: 0 0 0 1px #d1d6db;
 }
 
 .c0::-webkit-input-placeholder {
@@ -46,7 +46,7 @@ exports[`Input it renders 1`] = `
 .c0:focus {
   outline: 0;
   border-color: #007aff;
-  box-shadow: 0 0 0 1px #007aff;
+  box-shadow: 0 0 0 2px #007aff;
 }
 
 <input
@@ -65,7 +65,7 @@ exports[`Input it renders an input element with a really large padding and margi
   font-size: 14px;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 1px;
+  border-width: 0px;
   border-style: solid;
   border-color: #d1d6db;
   padding-top: 14px;
@@ -74,7 +74,7 @@ exports[`Input it renders an input element with a really large padding and margi
   padding-right: 12px;
   margin: 0;
   border-color: #d1d6db;
-  box-shadow: 0 0 0 0 #d1d6db;
+  box-shadow: 0 0 0 1px #d1d6db;
   margin: 32px;
   padding: 32px;
 }
@@ -102,7 +102,7 @@ exports[`Input it renders an input element with a really large padding and margi
 .c0:focus {
   outline: 0;
   border-color: #007aff;
-  box-shadow: 0 0 0 1px #007aff;
+  box-shadow: 0 0 0 2px #007aff;
 }
 
 <input
@@ -121,7 +121,7 @@ exports[`Input it renders an input element with a red border with a color prop i
   font-size: 14px;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 1px;
+  border-width: 0px;
   border-style: solid;
   border-color: #d1d6db;
   padding-top: 14px;
@@ -130,7 +130,7 @@ exports[`Input it renders an input element with a red border with a color prop i
   padding-right: 12px;
   margin: 0;
   border-color: #c00;
-  box-shadow: 0 0 0 0 #c00;
+  box-shadow: 0 0 0 1px #c00;
 }
 
 .c0::-webkit-input-placeholder {
@@ -156,7 +156,7 @@ exports[`Input it renders an input element with a red border with a color prop i
 .c0:focus {
   outline: 0;
   border-color: #c00;
-  box-shadow: 0 0 0 1px #c00;
+  box-shadow: 0 0 0 2px #c00;
 }
 
 <input
@@ -176,7 +176,7 @@ exports[`Input it renders an input element with large text 1`] = `
   font-size: 14px;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 1px;
+  border-width: 0px;
   border-style: solid;
   border-color: #d1d6db;
   padding-top: 14px;
@@ -185,7 +185,7 @@ exports[`Input it renders an input element with large text 1`] = `
   padding-right: 12px;
   margin: 0;
   border-color: #d1d6db;
-  box-shadow: 0 0 0 0 #d1d6db;
+  box-shadow: 0 0 0 1px #d1d6db;
 }
 
 .c0::-webkit-input-placeholder {
@@ -211,7 +211,7 @@ exports[`Input it renders an input element with large text 1`] = `
 .c0:focus {
   outline: 0;
   border-color: #007aff;
-  box-shadow: 0 0 0 1px #007aff;
+  box-shadow: 0 0 0 2px #007aff;
 }
 
 <input

--- a/src/__tests__/__snapshots__/InputField.js.snap
+++ b/src/__tests__/__snapshots__/InputField.js.snap
@@ -41,7 +41,7 @@ exports[`InputField it always renders a label when \`alwaysShowLabel\` is true 1
   font-size: 14px;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 1px;
+  border-width: 0px;
   border-style: solid;
   border-color: #d1d6db;
   padding-top: 14px;
@@ -50,7 +50,7 @@ exports[`InputField it always renders a label when \`alwaysShowLabel\` is true 1
   padding-right: 12px;
   margin: 0;
   border-color: #d1d6db;
-  box-shadow: 0 0 0 0 #d1d6db;
+  box-shadow: 0 0 0 1px #d1d6db;
   margin-top: -20px;
   padding-left: 40px;
   padding-right: 40px;
@@ -79,7 +79,7 @@ exports[`InputField it always renders a label when \`alwaysShowLabel\` is true 1
 .c4:focus {
   outline: 0;
   border-color: #007aff;
-  box-shadow: 0 0 0 1px #007aff;
+  box-shadow: 0 0 0 2px #007aff;
 }
 
 .c0 {
@@ -91,7 +91,7 @@ exports[`InputField it always renders a label when \`alwaysShowLabel\` is true 1
   display: block;
   width: 100%;
   margin: 0;
-  margin-top: 5px;
+  margin-top: 6px;
   padding-left: 40px;
   font-size: 10px;
   color: #687B8E;
@@ -210,7 +210,7 @@ exports[`InputField it renders a form field wth a label and icons 1`] = `
   font-size: 14px;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 1px;
+  border-width: 0px;
   border-style: solid;
   border-color: #d1d6db;
   padding-top: 14px;
@@ -219,7 +219,7 @@ exports[`InputField it renders a form field wth a label and icons 1`] = `
   padding-right: 12px;
   margin: 0;
   border-color: #d1d6db;
-  box-shadow: 0 0 0 0 #d1d6db;
+  box-shadow: 0 0 0 1px #d1d6db;
   padding-left: 40px;
   padding-right: 40px;
 }
@@ -247,7 +247,7 @@ exports[`InputField it renders a form field wth a label and icons 1`] = `
 .c3:focus {
   outline: 0;
   border-color: #007aff;
-  box-shadow: 0 0 0 1px #007aff;
+  box-shadow: 0 0 0 2px #007aff;
 }
 
 <div
@@ -348,7 +348,7 @@ exports[`InputField it renders a with a both icons 1`] = `
   font-size: 14px;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 1px;
+  border-width: 0px;
   border-style: solid;
   border-color: #d1d6db;
   padding-top: 14px;
@@ -357,7 +357,7 @@ exports[`InputField it renders a with a both icons 1`] = `
   padding-right: 12px;
   margin: 0;
   border-color: #d1d6db;
-  box-shadow: 0 0 0 0 #d1d6db;
+  box-shadow: 0 0 0 1px #d1d6db;
   padding-left: 40px;
   padding-right: 40px;
 }
@@ -385,7 +385,7 @@ exports[`InputField it renders a with a both icons 1`] = `
 .c3:focus {
   outline: 0;
   border-color: #007aff;
-  box-shadow: 0 0 0 1px #007aff;
+  box-shadow: 0 0 0 2px #007aff;
 }
 
 <div
@@ -469,7 +469,7 @@ exports[`InputField it renders a with a conditional right side icon 1`] = `
   font-size: 14px;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 1px;
+  border-width: 0px;
   border-style: solid;
   border-color: #d1d6db;
   padding-top: 14px;
@@ -478,7 +478,7 @@ exports[`InputField it renders a with a conditional right side icon 1`] = `
   padding-right: 12px;
   margin: 0;
   border-color: #d1d6db;
-  box-shadow: 0 0 0 0 #d1d6db;
+  box-shadow: 0 0 0 1px #d1d6db;
   padding-left: 8px;
 }
 
@@ -505,7 +505,7 @@ exports[`InputField it renders a with a conditional right side icon 1`] = `
 .c1:focus {
   outline: 0;
   border-color: #007aff;
-  box-shadow: 0 0 0 1px #007aff;
+  box-shadow: 0 0 0 2px #007aff;
 }
 
 <div
@@ -569,7 +569,7 @@ exports[`InputField it renders a with a left side icon 1`] = `
   font-size: 14px;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 1px;
+  border-width: 0px;
   border-style: solid;
   border-color: #d1d6db;
   padding-top: 14px;
@@ -578,7 +578,7 @@ exports[`InputField it renders a with a left side icon 1`] = `
   padding-right: 12px;
   margin: 0;
   border-color: #d1d6db;
-  box-shadow: 0 0 0 0 #d1d6db;
+  box-shadow: 0 0 0 1px #d1d6db;
   padding-left: 40px;
 }
 
@@ -605,7 +605,7 @@ exports[`InputField it renders a with a left side icon 1`] = `
 .c3:focus {
   outline: 0;
   border-color: #007aff;
-  box-shadow: 0 0 0 1px #007aff;
+  box-shadow: 0 0 0 2px #007aff;
 }
 
 <div
@@ -684,7 +684,7 @@ exports[`InputField it renders a with a right side icon 1`] = `
   font-size: 14px;
   background-color: transparent;
   border-radius: 2px;
-  border-width: 1px;
+  border-width: 0px;
   border-style: solid;
   border-color: #d1d6db;
   padding-top: 14px;
@@ -693,7 +693,7 @@ exports[`InputField it renders a with a right side icon 1`] = `
   padding-right: 12px;
   margin: 0;
   border-color: #d1d6db;
-  box-shadow: 0 0 0 0 #d1d6db;
+  box-shadow: 0 0 0 1px #d1d6db;
   padding-left: 8px;
   padding-right: 40px;
 }
@@ -721,7 +721,7 @@ exports[`InputField it renders a with a right side icon 1`] = `
 .c1:focus {
   outline: 0;
   border-color: #007aff;
-  box-shadow: 0 0 0 1px #007aff;
+  box-shadow: 0 0 0 2px #007aff;
 }
 
 <div


### PR DESCRIPTION
This is a follow-up PR based on the suggestions in https://github.com/pricelinelabs/design-system/pull/218

Replaced the border with a box shadow as @odmin and @msafari suggested
![inputfieldboxshadow](https://user-images.githubusercontent.com/1385339/37789925-8df8dbc8-2ddb-11e8-84d7-5fc0a394607b.gif)
