### PR TITLE
Use Input value to determine label visibility in InputField

### DIFF
--- a/.storybook/InputField.js
+++ b/.storybook/InputField.js
@@ -209,7 +209,6 @@ class InputFieldWithController extends React.PureComponent {
   render() {
     return (
       <InputField
-        onChange={this.onChange}
         color={this.getBorderColor()}
         info={
           !this.state.isValid && this.state.isDirty
@@ -225,6 +224,7 @@ class InputFieldWithController extends React.PureComponent {
           id="form-field"
           value={this.state.value}
           placeholder="Enter a 5 letter word"
+          onChange={this.onChange}
         />
         <Icon name="fitness" />
       </InputField>

--- a/docs/InputField.md
+++ b/docs/InputField.md
@@ -3,10 +3,14 @@
 Use `<InputField />` component to combine `<Input />`, `<Label />`, and `<Icon />` components into a flexible input field that matches the style guide.
 
 ```.jsx
-<InputField onChange={() => {}}>
+<InputField>
   <Label>Email address</Label>
   <Icon name='email' size='20' />
-  <Input id='form-field-3' defaultValue='oliver@example.com' placeholder='Please enter an email address' />
+  <Input
+    id='form-field-3'
+    defaultValue='oliver@example.com'
+    placeholder='Please enter an email address'
+  />
 </InputField>
 ```
 
@@ -27,7 +31,7 @@ All error handling should be performed by the parent component. An example of ho
   width={'50%'}
   bg='white'
 >
-  <InputField onChange={this.props.onChange}>
+  <InputField>
     <Icon name='search' color='blue' size={18} />
     <Input
       id='some-input'
@@ -78,4 +82,3 @@ Prop | Type | Description
 ---|---|---
 children | array of components | Up to 4 components, two of which can be `<Icon/>`'s, one of which can be an `<Input />`, and one of which can be a `<Label />`. No other elements are supported.
 alwaysShowLabel | boolean | determines whether or not the label shows up statically
-onChange | function | change handler that is passed into the `<Input />` component. This needs to be passed in explicitly into `<InputField/>` so that the label can update when the user interacts with the '<Input />` component.

--- a/src/InputField.js
+++ b/src/InputField.js
@@ -36,29 +36,27 @@ const getInputStyles = showLabel => {
       }
 }
 
+const noop = () => {}
+
 class InputField extends React.Component {
-  constructor(props) {
-    super(props)
-
-    let hasInitialValue
-
-    React.Children.forEach(props.children, child => {
-      if (child && child.type === Input) {
-        hasInitialValue = !!child.props.value
-      }
-    })
-
-    this.state = {
-      showLabel: hasInitialValue
-    }
+  static defaultProps = {
+    // for backwards-compatibility
+    onChange: noop
   }
 
-  onInputChange = event => {
-    this.setState({
-      showLabel: event.target.value
-    })
+  // for backwards-compatibility
+  handleChange = onChange => e => {
+    this.props.onChange(e)
+    if (typeof onChange !== 'function') return
+    onChange(e)
+  }
 
-    this.props.onChange(event)
+  hasValue = () => {
+    const { children } = this.props
+    return React.Children.toArray(children).reduce(
+      (a, child) => a || (child && child.type === Input && !!child.props.value),
+      false
+    )
   }
 
   render() {
@@ -108,7 +106,7 @@ class InputField extends React.Component {
     }
 
     const showLabel =
-      this.props.alwaysShowLabel || (LabelChild && this.state.showLabel)
+      this.props.alwaysShowLabel || (LabelChild && this.hasValue())
 
     return (
       <Box>
@@ -132,11 +130,12 @@ class InputField extends React.Component {
             pl: BeforeIcon ? 40 : 2,
             pr: AfterIcon && 40,
             style: getInputStyles(showLabel),
-            onChange: this.onInputChange,
             width: 1,
             innerRef: elem => {
               this.inputRef = elem
             },
+            // for backwards compatibility
+            onChange: this.handleChange(InputChild.props.onChange),
             ...props
           })}
           {AfterIcon && (
@@ -151,7 +150,6 @@ class InputField extends React.Component {
 }
 
 InputField.propTypes = {
-  onChange: PropTypes.func.isRequired,
   alwaysShowLabel: PropTypes.bool,
   children: function(props, propName, componentName) {
     const prop = props[propName]

--- a/src/__tests__/InputField.js
+++ b/src/__tests__/InputField.js
@@ -112,7 +112,7 @@ describe('InputField', () => {
   })
   test('it correctly places an aria-label with the placeholder value before user has interacted with the input', () => {
     const test = mount(
-      <InputField onChange={() => {}}>
+      <InputField>
         <Label>A Label</Label>
         <Icon name="email" />
         <Input id="with-both-icons" placeholder="placeholder text" />
@@ -128,15 +128,33 @@ describe('InputField', () => {
     expect(input.getDOMNode().getAttribute('aria-label')).toBe(
       'placeholder text'
     )
+  })
 
-    input.simulate('change', { target: { value: 'asdf' } })
-
-    // After user interaction the Label component should be there, so we no longer need the aria-label attribute
-    label = test.find(Label)
+  test('it shows a label when the input has a value', () => {
+    const wrapper = mount(
+      <InputField>
+        <Label>Hello</Label>
+        <Input placeholder="Hello" value="Howdy" />
+      </InputField>
+    )
+    const label = wrapper.find(Label)
+    const input = wrapper.find(Input)
     expect(label.length).toBe(1)
-    input = test.find(Input)
     expect(input.getDOMNode().getAttribute('aria-label')).toBeFalsy()
   })
+
+  test('it calls onChange prop if provided', () => {
+    const onChange = jest.fn()
+    const wrapper = mount(
+      <InputField>
+        <Input onChange={onChange} />
+      </InputField>
+    )
+    const input = wrapper.find(Input)
+    input.simulate('change', { target: { value: 'hi' } })
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
   test('it triggers a prop-type warning when 3 icons are provided', () => {
     console.error = jest.fn()
 


### PR DESCRIPTION
Removes state from the InputField component, negating the need to pass an `onChange` prop. I've added some code to support backwards compatibility with the current API, but would like some input from @byrekt in case I'm missing something about the implementation here