### PR TITLE
fix(Flag): allow hex to be passed in as bg prop

### DIFF
--- a/.storybook/Flag.js
+++ b/.storybook/Flag.js
@@ -27,11 +27,20 @@ storiesOf('Flag', module)
     </Box>
   ))
 
-  .add('with darkBgColors', () => (
+  .add('with custom hex bg color', () => (
     <Box p={3}>
       <Card pb={3}>
-        <Flag width={192} mt={2} bg="#085397" darkBgColor="#022647">
-          <b>Hello</b> with custom hex colors
+        <Flag width={192} mt={2} bg="#085397">
+          <b>Hello</b> #085397
+        </Flag>
+        <Flag width={192} mt={2} bg="#f2633a">
+          <b>Hello</b> #f2633a
+        </Flag>
+        <Flag width={192} mt={2} bg="#0a84c1">
+          <b>Hello</b> #0a84c1
+        </Flag>
+        <Flag width={192} mt={2} bg="#3c910e">
+          <b>Hello</b> #3c910e
         </Flag>
       </Card>
     </Box>

--- a/.storybook/Flag.js
+++ b/.storybook/Flag.js
@@ -26,6 +26,16 @@ storiesOf('Flag', module)
       </Card>
     </Box>
   ))
+
+  .add('with darkBgColors', () => (
+    <Box p={3}>
+      <Card pb={3}>
+        <Flag width={192} mt={2} bg="#085397" darkBgColor="#022647">
+          <b>Hello</b> with custom hex colors
+        </Flag>
+      </Card>
+    </Box>
+  ))
   .add('Compensating for 1px border', () => (
     <Box p={3}>
       <Card pb={3}>

--- a/docs/Flag.md
+++ b/docs/Flag.md
@@ -23,4 +23,3 @@ Prop | Type | Description
 ---|---|---
 color | string | text color
 bg | string | background color
-darkBgColor | string | background color for flag shadow

--- a/docs/Flag.md
+++ b/docs/Flag.md
@@ -23,3 +23,4 @@ Prop | Type | Description
 ---|---|---
 color | string | text color
 bg | string | background color
+darkBgColor | string | background color for flag shadow

--- a/src/Flag.js
+++ b/src/Flag.js
@@ -29,7 +29,8 @@ const FlagShadow = styled(Box)`
 
 const FlagRight = styled(Box)`
   flex: none;
-  background-color: ${props => theme(`colors.${props.color}`)(props)};
+  background-color: ${props =>
+    theme(`colors.${props.color}`)(props) || props.color};
   border-radius: 0 ${theme('radius')} ${theme('radius')} 0;
   /* for 32 x 8 triangle */
   transform: skew(-14deg);

--- a/src/Flag.js
+++ b/src/Flag.js
@@ -8,7 +8,8 @@ import Box from './Box'
 const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1)
 
 const darkBorderColor = props => {
-  const darkColor = theme(`colors.dark${capitalize(props.color)}`)(props)
+  const darkColor =
+    props.darkBgColor || theme(`colors.dark${capitalize(props.color)}`)(props)
   return {
     borderTopColor: darkColor,
     borderRightColor: darkColor
@@ -54,10 +55,16 @@ const RelativeHide = styled(Hide)`
   position: relative;
 `
 
-const Flag = ({ color, bg, children, width, ...props }) => (
+const Flag = ({ color, bg, darkBgColor, children, width, ...props }) => (
   <Flex width={width} {...props} ml={[0, -2]}>
     <RelativeHide xs>
-      <FlagShadow width="4px" mr={-2} mb={-2} color={bg} />
+      <FlagShadow
+        width="4px"
+        mr={-2}
+        mb={-2}
+        color={bg}
+        darkBgColor={darkBgColor}
+      />
     </RelativeHide>
     <FlagBody flexAuto={!!width} color={color} bg={bg} py={[1, 2]} pl={[1, 3]}>
       {children}

--- a/src/Flag.js
+++ b/src/Flag.js
@@ -7,22 +7,28 @@ import Box from './Box'
 
 const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1)
 
-const darkBorderColor = props => {
-  const darkColor =
-    props.darkBgColor || theme(`colors.dark${capitalize(props.color)}`)(props)
+const shadowColor = props => {
+  const darkColor = theme(`colors.dark${capitalize(props.color)}`)(props)
+
+  if (!darkColor) {
+    return {
+      backgroundImage: `
+        linear-gradient(45deg, transparent 50%, rgba(0, 0, 0, 0.5) 50%),
+        linear-gradient(45deg, transparent 50%, ${props.color} 50%)
+      `
+    }
+  }
+
   return {
-    borderTopColor: darkColor,
-    borderRightColor: darkColor
+    backgroundImage: `linear-gradient(45deg, transparent 50%, ${darkColor} 50%)`
   }
 }
 
 const FlagShadow = styled(Box)`
-  height: 4px;
+  width: 8px;
+  height: 8px;
   align-self: flex-end;
-  border-width: 4px;
-  border-style: solid;
-  border-color: transparent;
-  ${darkBorderColor};
+  ${shadowColor};
   position: absolute;
   bottom: 0;
 `
@@ -30,7 +36,7 @@ const FlagShadow = styled(Box)`
 const FlagRight = styled(Box)`
   flex: none;
   background-color: ${props =>
-    theme(`colors.${props.color}`)(props) || props.color};
+    theme(`colors.${props.color}`, props.color)(props)};
   border-radius: 0 ${theme('radius')} ${theme('radius')} 0;
   /* for 32 x 8 triangle */
   transform: skew(-14deg);
@@ -56,16 +62,10 @@ const RelativeHide = styled(Hide)`
   position: relative;
 `
 
-const Flag = ({ color, bg, darkBgColor, children, width, ...props }) => (
+const Flag = ({ color, bg, children, width, ...props }) => (
   <Flex width={width} {...props} ml={[0, -2]}>
     <RelativeHide xs>
-      <FlagShadow
-        width="4px"
-        mr={-2}
-        mb={-2}
-        color={bg}
-        darkBgColor={darkBgColor}
-      />
+      <FlagShadow width="4px" mr={-2} mb={-2} color={bg} />
     </RelativeHide>
     <FlagBody flexAuto={!!width} color={color} bg={bg} py={[1, 2]} pl={[1, 3]}>
       {children}

--- a/src/Flag.js
+++ b/src/Flag.js
@@ -10,17 +10,13 @@ const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1)
 const shadowColor = props => {
   const darkColor = theme(`colors.dark${capitalize(props.color)}`)(props)
 
-  if (!darkColor) {
-    return {
-      backgroundImage: `
+  return {
+    backgroundImage: !darkColor
+      ? `
         linear-gradient(45deg, transparent 50%, rgba(0, 0, 0, 0.5) 50%),
         linear-gradient(45deg, transparent 50%, ${props.color} 50%)
       `
-    }
-  }
-
-  return {
-    backgroundImage: `linear-gradient(45deg, transparent 50%, ${darkColor} 50%)`
+      : `linear-gradient(45deg, transparent 50%, ${darkColor} 50%)`
   }
 }
 

--- a/src/__tests__/Flag.js
+++ b/src/__tests__/Flag.js
@@ -13,4 +13,11 @@ describe('Flag', () => {
     const json = renderer.create(<Flag width={256} />).toJSON()
     expect(json).toMatchSnapshot()
   })
+
+  test('renders with darkBgColor prop', () => {
+    const json = renderer
+      .create(<Flag width={256} bg="#085397" darkBgColor="#022647" />)
+      .toJSON()
+    expect(json).toMatchSnapshot()
+  })
 })

--- a/src/__tests__/Flag.js
+++ b/src/__tests__/Flag.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import 'jest-styled-components'
-import { Flag } from '..'
+import { ThemeProvider, Flag } from '..'
 
 describe('Flag', () => {
   test('renders', () => {
@@ -14,9 +14,18 @@ describe('Flag', () => {
     expect(json).toMatchSnapshot()
   })
 
-  test('renders with darkBgColor prop', () => {
+  test('renders with hex value as bg color', () => {
+    const json = renderer.create(<Flag width={256} bg="#085397" />).toJSON()
+    expect(json).toMatchSnapshot()
+  })
+
+  test('renders with theme color as bg color', () => {
     const json = renderer
-      .create(<Flag width={256} bg="#085397" darkBgColor="#022647" />)
+      .create(
+        <ThemeProvider>
+          <Flag width={256} bg="purple" />
+        </ThemeProvider>
+      )
       .toJSON()
     expect(json).toMatchSnapshot()
   })

--- a/src/__tests__/__snapshots__/Flag.js.snap
+++ b/src/__tests__/__snapshots__/Flag.js.snap
@@ -46,6 +46,7 @@ exports[`Flag renders 1`] = `
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
+  background-color: green;
   border-radius: 0 0;
   -webkit-transform: skew(-14deg);
   -ms-transform: skew(-14deg);
@@ -160,6 +161,7 @@ exports[`Flag renders with darkBgColor prop 1`] = `
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
+  background-color: #085397;
   border-radius: 0 0;
   -webkit-transform: skew(-14deg);
   -ms-transform: skew(-14deg);
@@ -275,6 +277,7 @@ exports[`Flag renders with width prop 1`] = `
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
+  background-color: green;
   border-radius: 0 0;
   -webkit-transform: skew(-14deg);
   -ms-transform: skew(-14deg);

--- a/src/__tests__/__snapshots__/Flag.js.snap
+++ b/src/__tests__/__snapshots__/Flag.js.snap
@@ -31,13 +31,12 @@ exports[`Flag renders 1`] = `
 }
 
 .c3 {
-  height: 4px;
+  width: 8px;
+  height: 8px;
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;
-  border-width: 4px;
-  border-style: solid;
-  border-color: transparent;
+  background-image: linear-gradient(45deg,transparent 50%,rgba(0,0,0,0.5) 50%), linear-gradient(45deg,transparent 50%,green 50%);
   position: absolute;
   bottom: 0;
 }
@@ -112,7 +111,7 @@ exports[`Flag renders 1`] = `
 </div>
 `;
 
-exports[`Flag renders with darkBgColor prop 1`] = `
+exports[`Flag renders with hex value as bg color 1`] = `
 .c4 {
   margin-bottom: -8px;
   margin-right: -8px;
@@ -144,15 +143,12 @@ exports[`Flag renders with darkBgColor prop 1`] = `
 }
 
 .c3 {
-  height: 4px;
+  width: 8px;
+  height: 8px;
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;
-  border-width: 4px;
-  border-style: solid;
-  border-color: transparent;
-  border-top-color: #022647;
-  border-right-color: #022647;
+  background-image: linear-gradient(45deg,transparent 50%,rgba(0,0,0,0.5) 50%), linear-gradient(45deg,transparent 50%,#085397 50%);
   position: absolute;
   bottom: 0;
 }
@@ -230,6 +226,134 @@ exports[`Flag renders with darkBgColor prop 1`] = `
 </div>
 `;
 
+exports[`Flag renders with theme color as bg color 1`] = `
+.c5 {
+  margin-bottom: -8px;
+  margin-right: -8px;
+  width: 4px;
+  color: #70b;
+}
+
+.c7 {
+  padding-left: 4px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  color: #fff;
+  background-color: #70b;
+}
+
+.c9 {
+  margin-left: -8px;
+  width: 18px;
+  color: #70b;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-left: 0px;
+  width: 256px;
+}
+
+.c4 {
+  width: 8px;
+  height: 8px;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  background-image: linear-gradient(45deg,transparent 50%,#407 50%);
+  position: absolute;
+  bottom: 0;
+}
+
+.c8 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  background-color: #70b;
+  border-radius: 0 2px 2px 0;
+  -webkit-transform: skew(-14deg);
+  -ms-transform: skew(-14deg);
+  transform: skew(-14deg);
+  position: relative;
+  z-index: 1;
+}
+
+.c6 {
+  font-size: 12px;
+  border-radius: 0 0 2px 0;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  color: #fff;
+  background-color: #70b;
+  z-index: 2;
+}
+
+.c2 {
+  position: relative;
+}
+
+.c0 {
+  font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.4;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+@media screen and (min-width:32em) {
+  .c7 {
+    padding-left: 16px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c1 {
+    margin-left: -8px;
+  }
+}
+
+@media screen and (max-width:31.99em) {
+  .c3 {
+    display: none;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+    width={256}
+  >
+    <div
+      className="c2 c3 "
+    >
+      <div
+        className="c4 c5"
+        color="purple"
+        width="4px"
+      />
+    </div>
+    <div
+      className="c6 c7"
+      color="white"
+    />
+    <div
+      className="c8 c9"
+      color="purple"
+      width="18px"
+    />
+  </div>
+</div>
+`;
+
 exports[`Flag renders with width prop 1`] = `
 .c4 {
   margin-bottom: -8px;
@@ -262,13 +386,12 @@ exports[`Flag renders with width prop 1`] = `
 }
 
 .c3 {
-  height: 4px;
+  width: 8px;
+  height: 8px;
   -webkit-align-self: flex-end;
   -ms-flex-item-align: end;
   align-self: flex-end;
-  border-width: 4px;
-  border-style: solid;
-  border-color: transparent;
+  background-image: linear-gradient(45deg,transparent 50%,rgba(0,0,0,0.5) 50%), linear-gradient(45deg,transparent 50%,green 50%);
   position: absolute;
   bottom: 0;
 }

--- a/src/__tests__/__snapshots__/Flag.js.snap
+++ b/src/__tests__/__snapshots__/Flag.js.snap
@@ -111,6 +111,123 @@ exports[`Flag renders 1`] = `
 </div>
 `;
 
+exports[`Flag renders with darkBgColor prop 1`] = `
+.c4 {
+  margin-bottom: -8px;
+  margin-right: -8px;
+  width: 4px;
+  color: #085397;
+}
+
+.c6 {
+  padding-left: 4px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  color: #fff;
+  background-color: #085397;
+}
+
+.c8 {
+  margin-left: -8px;
+  width: 18px;
+  color: #085397;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-left: 0px;
+  width: 256px;
+}
+
+.c3 {
+  height: 4px;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  border-width: 4px;
+  border-style: solid;
+  border-color: transparent;
+  border-top-color: #022647;
+  border-right-color: #022647;
+  position: absolute;
+  bottom: 0;
+}
+
+.c7 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  border-radius: 0 0;
+  -webkit-transform: skew(-14deg);
+  -ms-transform: skew(-14deg);
+  transform: skew(-14deg);
+  position: relative;
+  z-index: 1;
+}
+
+.c5 {
+  font-size: px;
+  border-radius: 0 0 0;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  color: white;
+  background-color: #085397;
+  z-index: 2;
+}
+
+.c1 {
+  position: relative;
+}
+
+@media screen and (min-width:32em) {
+  .c6 {
+    padding-left: 16px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+}
+
+@media screen and (min-width:32em) {
+  .c0 {
+    margin-left: -8px;
+  }
+}
+
+@media screen and (max-width:31.99em) {
+  .c2 {
+    display: none;
+  }
+}
+
+<div
+  className="c0"
+  width={256}
+>
+  <div
+    className="c1 c2 "
+  >
+    <div
+      className="c3 c4"
+      color="#085397"
+      width="4px"
+    />
+  </div>
+  <div
+    className="c5 c6"
+    color="white"
+  />
+  <div
+    className="c7 c8"
+    color="#085397"
+    width="18px"
+  />
+</div>
+`;
+
 exports[`Flag renders with width prop 1`] = `
 .c4 {
   margin-bottom: -8px;


### PR DESCRIPTION
problem:
if we passed in hex values directly to Flag, the UI was kinda broken.
<img width="537" alt="screen shot 2018-04-24 at 9 13 33 am" src="https://user-images.githubusercontent.com/5679105/39189601-9cc467f6-47a0-11e8-9b9a-1c7628fe48c8.png">

fixed:
<img width="368" alt="screen shot 2018-04-24 at 9 33 55 pm" src="https://user-images.githubusercontent.com/5679105/39221826-3837a2b4-4807-11e8-9f97-a304e1ae414c.png">


