### PR TITLE
fix(Flag): remove theme as default prop for Flag

### DIFF
--- a/src/Flag.js
+++ b/src/Flag.js
@@ -76,8 +76,7 @@ Flag.propTypes = {
 
 Flag.defaultProps = {
   color: 'white',
-  bg: 'green',
-  theme: theme
+  bg: 'green'
 }
 
 Flag.displayName = 'Flag'

--- a/src/__tests__/__snapshots__/Flag.js.snap
+++ b/src/__tests__/__snapshots__/Flag.js.snap
@@ -74,9 +74,9 @@ exports[`Flag renders 1`] = `
   }
 }
 
-@media screen and (min-width:40em) {
+@media screen and (min-width:32em) {
   .c0 {
-    margin-left: -16px;
+    margin-left: -8px;
   }
 }
 
@@ -189,9 +189,9 @@ exports[`Flag renders with hex value as bg color 1`] = `
   }
 }
 
-@media screen and (min-width:40em) {
+@media screen and (min-width:32em) {
   .c0 {
-    margin-left: -16px;
+    margin-left: -8px;
   }
 }
 
@@ -313,9 +313,9 @@ exports[`Flag renders with theme color as bg color 1`] = `
   }
 }
 
-@media screen and (min-width:40em) {
+@media screen and (min-width:32em) {
   .c1 {
-    margin-left: -16px;
+    margin-left: -8px;
   }
 }
 
@@ -432,9 +432,9 @@ exports[`Flag renders with width prop 1`] = `
   }
 }
 
-@media screen and (min-width:40em) {
+@media screen and (min-width:32em) {
   .c0 {
-    margin-left: -16px;
+    margin-left: -8px;
   }
 }
 


### PR DESCRIPTION
looks like adding the default theme as prop-type messes up the styles. I don't believe this component needs theme as a default prop for unit testing

Styles with default theme were broken:
<img width="235" alt="screen shot 2018-04-30 at 10 32 59 am" src="https://user-images.githubusercontent.com/5679105/39435391-49f51796-4c69-11e8-87d6-0789d3aa1b02.png">
