### PR TITLE
Button with `<a>` styling fix

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -7,27 +7,23 @@ const size = props => {
   switch (props.size) {
     case 'small':
       return {
-        height: '32px',
         fontSize: `${props.theme.fontSizes[0]}px`,
-        padding: '0 12px'
+        padding: '7px 12px'
       }
     case 'medium':
       return {
-        height: '40px',
         fontSize: `${props.theme.fontSizes[1]}px`,
-        padding: '0 18px'
+        padding: '9.5px 18px'
       }
     case 'large':
       return {
-        height: '48px',
         fontSize: `${props.theme.fontSizes[2]}px`,
-        padding: '0 22px'
+        padding: '12px 22px'
       }
     default:
       return {
-        height: '40px',
         fontSize: `${props.theme.fontSizes[1]}px`,
-        padding: '0 18px'
+        padding: '9.5px 18px'
       }
   }
 }
@@ -42,6 +38,7 @@ const Button = styled.button`
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: ${props => props.theme.radius};
   background-color: ${props => props.theme.colors.blue};

--- a/src/__tests__/Button.js
+++ b/src/__tests__/Button.js
@@ -11,7 +11,6 @@ describe('Button', () => {
   test('size small sets height and font-size', () => {
     const json = renderer.create(<Button size="small" />).toJSON()
     expect(json).toMatchSnapshot()
-    expect(json).toHaveStyleRule('height', '32px')
     expect(json).toHaveStyleRule('font-size', '12px')
     expect(json).toHaveStyleRule('background-color', theme.colors.blue)
     expect(json).toHaveStyleRule('color', theme.colors.white)
@@ -20,14 +19,12 @@ describe('Button', () => {
   test('size medium sets height and font-size', () => {
     const json = renderer.create(<Button size="medium" />).toJSON()
     expect(json).toMatchSnapshot()
-    expect(json).toHaveStyleRule('height', '40px')
     expect(json).toHaveStyleRule('font-size', '14px')
   })
 
   test('size large sets height and font-size', () => {
     const json = renderer.create(<Button size="large" />).toJSON()
     expect(json).toMatchSnapshot()
-    expect(json).toHaveStyleRule('height', '48px')
     expect(json).toHaveStyleRule('font-size', '16px')
   })
 

--- a/src/__tests__/__snapshots__/Button.js.snap
+++ b/src/__tests__/__snapshots__/Button.js.snap
@@ -10,15 +10,15 @@ exports[`Button disabled prop sets 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c0:disabled {
@@ -41,6 +41,7 @@ exports[`Button fullWidth prop sets width to 100% 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
@@ -48,9 +49,8 @@ exports[`Button fullWidth prop sets width to 100% 1`] = `
   border-width: 0;
   border-style: solid;
   width: 100%;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c0:disabled {
@@ -76,15 +76,15 @@ exports[`Button renders 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c0:disabled {
@@ -110,15 +110,15 @@ exports[`Button size large sets height and font-size 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 48px;
   font-size: 16px;
-  padding: 0 22px;
+  padding: 12px 22px;
 }
 
 .c0:disabled {
@@ -145,15 +145,15 @@ exports[`Button size medium sets height and font-size 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c0:disabled {
@@ -180,15 +180,15 @@ exports[`Button size small sets height and font-size 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 32px;
   font-size: 12px;
-  padding: 0 12px;
+  padding: 7px 12px;
 }
 
 .c0:disabled {
@@ -215,15 +215,15 @@ exports[`Button without disabled prop sets 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c0:disabled {

--- a/src/__tests__/__snapshots__/CloseButton.js.snap
+++ b/src/__tests__/__snapshots__/CloseButton.js.snap
@@ -16,15 +16,15 @@ exports[`CloseButton renders without props 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c1:disabled {

--- a/src/__tests__/__snapshots__/GreenButton.js.snap
+++ b/src/__tests__/__snapshots__/GreenButton.js.snap
@@ -10,15 +10,15 @@ exports[`GreenButton disabled prop sets 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c1:disabled {
@@ -45,15 +45,15 @@ exports[`GreenButton renders 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c1:disabled {
@@ -87,15 +87,15 @@ exports[`GreenButton without disabled prop sets 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c1:disabled {

--- a/src/__tests__/__snapshots__/IconButton.js.snap
+++ b/src/__tests__/__snapshots__/IconButton.js.snap
@@ -16,15 +16,15 @@ exports[`IconButton renders without props 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c1:disabled {

--- a/src/__tests__/__snapshots__/OutlineButton.js.snap
+++ b/src/__tests__/__snapshots__/OutlineButton.js.snap
@@ -10,15 +10,15 @@ exports[`OutlineButton disabled prop sets 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c1:disabled {
@@ -53,15 +53,15 @@ exports[`OutlineButton renders 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c1:disabled {
@@ -101,15 +101,15 @@ exports[`OutlineButton without disabled prop sets 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c1:disabled {

--- a/src/__tests__/__snapshots__/RedButton.js.snap
+++ b/src/__tests__/__snapshots__/RedButton.js.snap
@@ -10,15 +10,15 @@ exports[`RedButton disabled prop sets 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c1:disabled {
@@ -45,15 +45,15 @@ exports[`RedButton renders 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c1:disabled {
@@ -87,15 +87,15 @@ exports[`RedButton without disabled prop sets 1`] = `
   text-decoration: none;
   font-family: inherit;
   font-weight: 600;
+  line-height: 1.5;
   cursor: pointer;
   border-radius: 2px;
   background-color: #007aff;
   color: #fff;
   border-width: 0;
   border-style: solid;
-  height: 40px;
   font-size: 14px;
-  padding: 0 18px;
+  padding: 9.5px 18px;
 }
 
 .c1:disabled {


### PR DESCRIPTION
This fixes #285 — I removed set heights and added line-heights and top/bottom padding to the button component. This allows for buttons to wrap to 2 or more lines if needed as well as fixes the line-height issue seen when adding `<a>` to a button component.