### PR TITLE
Add contribution instructions for static docs site

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -62,14 +62,13 @@ open http://localhost:8000/
 
 ### Static Docs Site
 
-Markdown and source code for the [static docs site](https://pricelinelabs.github.io/design-system/) is located in
+Markdown and source code for the [static docs site](https://pricelinelabs.github.io/design-system/) are located in
 `docs/`. This [x0](https://www.npmjs.com/package/@compositor/x0) project requires Node 7+.
 
 To run the static docs locally:
 
 ```sh
 cd docs
-npm install -g @compositor/x0
 npm install
 npm start
 ```

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -63,7 +63,7 @@ open http://localhost:8000/
 ### Static Docs Site
 
 Markdown and source code for the [static docs site](https://pricelinelabs.github.io/design-system/) are located in
-`docs/`. This [x0](https://www.npmjs.com/package/@compositor/x0) project requires Node 7+.
+`docs/`. This [x0](https://www.npmjs.com/package/@compositor/x0) project requires Node 8+.
 
 To run the static docs locally:
 

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -60,6 +60,20 @@ npm start
 open http://localhost:8000/
 ```
 
+### Static Docs Site
+
+Markdown and source code for the [static docs site](https://pricelinelabs.github.io/design-system/) is located in
+`docs/`. This [x0](https://www.npmjs.com/package/@compositor/x0) project requires Node 7+.
+
+To run the static docs locally:
+
+```sh
+cd docs
+npm install -g @compositor/x0
+npm install
+npm start
+```
+
 
 ### Troubleshooting
 


### PR DESCRIPTION
It's not immediately obvious how to make changes to the static site docs. This should make it easier for new people to get started.