### PR TITLE
Fix toggle font

### DIFF
--- a/docs/ToggleBadge.md
+++ b/docs/ToggleBadge.md
@@ -15,7 +15,7 @@ Use the `<ToggleBadge />` component to render a primitive badge.
 
 Prop | Type | Description
 ---|---|---
-selected | boolean | gives different background color and makes font bold
+selected | boolean | gives different background color
 color | string | text color
 bg | string | background color of the toggle badge
 fontSize | number or array | text font size

--- a/src/ToggleBadge.js
+++ b/src/ToggleBadge.js
@@ -8,8 +8,7 @@ const ToggleBadge = styled.button`
   border-radius: ${props => props.theme.radius};
   border: 0;
   display: inline-block;
-  font-weight: ${props =>
-    props.selected ? props.theme.bold : props.theme.regular};
+  font-weight: ${props => props.theme.regular};
   font-family: inherit;
   cursor: pointer;
   background-color: ${props =>

--- a/src/ToggleBadge.js
+++ b/src/ToggleBadge.js
@@ -8,7 +8,7 @@ const ToggleBadge = styled.button`
   border-radius: ${props => props.theme.radius};
   border: 0;
   display: inline-block;
-  font-weight: ${props => props.theme.regular};
+  font-weight: ${props => props.theme.bold};
   font-family: inherit;
   cursor: pointer;
   background-color: ${props =>

--- a/src/__tests__/__snapshots__/ToggleBadge.js.snap
+++ b/src/__tests__/__snapshots__/ToggleBadge.js.snap
@@ -5,7 +5,7 @@ exports[`ToggleBadge selected ToggleBadge renders with default props 1`] = `
   border-radius: 2px;
   border: 0;
   display: inline-block;
-  font-weight: 400;
+  font-weight: 600;
   font-family: inherit;
   cursor: pointer;
   background-color: #cdf;
@@ -38,7 +38,7 @@ exports[`ToggleBadge selected one with background-color and text color passed as
   border-radius: 2px;
   border: 0;
   display: inline-block;
-  font-weight: 400;
+  font-weight: 600;
   font-family: inherit;
   cursor: pointer;
   background-color: #0a0;
@@ -71,7 +71,7 @@ exports[`ToggleBadge unselected ToggleBadge renders with default props 1`] = `
   border-radius: 2px;
   border: 0;
   display: inline-block;
-  font-weight: 400;
+  font-weight: 600;
   font-family: inherit;
   cursor: pointer;
   background-color: #fff;

--- a/src/__tests__/__snapshots__/ToggleBadge.js.snap
+++ b/src/__tests__/__snapshots__/ToggleBadge.js.snap
@@ -5,7 +5,7 @@ exports[`ToggleBadge selected ToggleBadge renders with default props 1`] = `
   border-radius: 2px;
   border: 0;
   display: inline-block;
-  font-weight: 600;
+  font-weight: 400;
   font-family: inherit;
   cursor: pointer;
   background-color: #cdf;
@@ -38,7 +38,7 @@ exports[`ToggleBadge selected one with background-color and text color passed as
   border-radius: 2px;
   border: 0;
   display: inline-block;
-  font-weight: 600;
+  font-weight: 400;
   font-family: inherit;
   cursor: pointer;
   background-color: #0a0;


### PR DESCRIPTION
Undo the change for `<ToggleBadge>` to let it change text font-weight on selection. Now it will be bold always.