### PR TITLE
Fix docs URL basepath

### DIFF
--- a/docs/.babelrc
+++ b/docs/.babelrc
@@ -1,8 +1,0 @@
-{
-  presets: [
-    'next/babel'
-  ],
-  plugins: [
-    'babel-plugin-styled-components'
-  ]
-}

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['next/babel'],
+  plugins: ['babel-plugin-styled-components']
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,9 +19,9 @@
   },
   "devDependencies": {
     "@mdx-js/loader": "^0.15.5",
-    "babel-loader": "^7.1.5",
+    "babel-loader": "^8.0.4",
     "babel-plugin-styled-components": "^1.8.0",
-    "next": "^6.1.1",
+    "next": "^7.0.2",
     "next-mdx-docs": "0.0.1-0",
     "remark-autolink-headings": "^5.0.0",
     "remark-emoji": "^2.0.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "build": "next build && next export"
   },
   "dependencies": {
-    "@mdx-js/mdx": "^0.15.0",
+    "@mdx-js/mdx": "^0.15.5",
     "@mdx-js/tag": "^0.15.0",
     "is-absolute-url": "^2.1.0",
     "mdx-docs": "^1.0.0-9",
@@ -15,16 +15,16 @@
     "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
-    "styled-components": "^3.3.3"
+    "styled-components": "^3.4.10"
   },
   "devDependencies": {
-    "@mdx-js/loader": "^0.15.0",
+    "@mdx-js/loader": "^0.15.5",
     "babel-loader": "^7.1.5",
-    "babel-plugin-styled-components": "^1.5.1",
+    "babel-plugin-styled-components": "^1.8.0",
     "next": "^6.1.1",
     "next-mdx-docs": "0.0.1-0",
     "remark-autolink-headings": "^5.0.0",
-    "remark-emoji": "^2.0.1",
+    "remark-emoji": "^2.0.2",
     "remark-images": "^0.8.1",
     "remark-slug": "^5.1.0"
   }

--- a/docs/pages/Icon.md
+++ b/docs/pages/Icon.md
@@ -31,4 +31,4 @@ Prop | Type | Description
 `color` | string | A color key from `theme.colors`
 `legacy` | boolean | Force component to prefer using icons from the legacy set
 
-For a full list of available icons, see [Iconography](/design-system/iconography).
+For a full list of available icons, see [Iconography](/iconography).

--- a/docs/src/components.js
+++ b/docs/src/components.js
@@ -2,6 +2,21 @@ import * as DS from 'pcln-design-system'
 import { Heading, Text, Link, BlockLink, Button } from 'pcln-design-system'
 import styled from 'styled-components'
 import { space, fontSize, color, theme } from 'styled-system'
+import { components as mdxDocsComponents } from 'mdx-docs'
+
+const RouterLink = styled(mdxDocsComponents.a)(
+  {
+    textDecoration: 'none',
+    '&:hover': {
+      textDecoration: 'underline'
+    }
+  },
+  color
+)
+
+RouterLink.defaultProps = {
+  color: 'blue'
+}
 
 const heading = type => props => {
   const Comp = Heading[type]
@@ -83,7 +98,7 @@ const components = {
   h4: heading('h4'),
   h5: heading('h5'),
   h6: heading('h6'),
-  a: Link,
+  a: RouterLink,
   p: p => <Text.p {...p} />,
   table: Table
 }


### PR DESCRIPTION
Fixes #363 

- Uses the link component from mdx-docs in markdown to correctly handle base path since Next.js does not current support (see https://github.com/zeit/next.js/issues/4998)
- Updates dependencies for docs site