### PR TITLE
fix(rc-slider): only import range to avoid bundling rc-tooltip

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Range } from 'rc-slider'
+import Range from 'rc-slider/lib/Range'
 import { space, color, theme as getTheme, propTypes } from 'styled-system'
 import theme from './theme'
 


### PR DESCRIPTION
Since we're doing a named import, it's gonna bundle up everything in their `index.js` file in pcln-design-system. 
For example, one of the things that gets bundled up is rc-tooltip which is only used in `createSliderWithTooltip`. But we only need Range looks like. we can reduce the size of rc-slider we're shipping out by just changing this import