### PR TITLE
fix(ThemeProvider): Removed injectGlobal from ThemeProvider so styled…

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -22,7 +22,7 @@ Follow these steps to migrate from v1 to v2
 - Ensure Heading component has appropriately set styles. If your application relied on the styles with the `Heading.h1` – `Heading.h6` semantic components, use the new `textStyle` prop to set styles (e.g. `<Heading.h1 textStyle='display6' />`)
 - Account for other typographic changes (#231)
 - Update dependencies if your application has the following in its `package.json`:
-  - `styled-components` >=3.0.0 or >=4.0.0
+  - `styled-components` >=2.0.0 || >=3.0.0 || >=4.0.0
   - `styled-system` >=3.0.0
 - Account for ThemeProvider no longer using the deprecated `injectGlobal` therby not setting `body { margin: 0 }`
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -22,6 +22,7 @@ Follow these steps to migrate from v1 to v2
 - Ensure Heading component has appropriately set styles. If your application relied on the styles with the `Heading.h1` – `Heading.h6` semantic components, use the new `textStyle` prop to set styles (e.g. `<Heading.h1 textStyle='display6' />`)
 - Account for other typographic changes (#231)
 - Update dependencies if your application has the following in its `package.json`:
-  - `styled-components` >=3.0.0
+  - `styled-components` >=3.0.0 or >=4.0.0
   - `styled-system` >=3.0.0
+- Account for ThemeProvider no longer using the deprecated `injectGlobal` therby not setting `body { margin: 0 }`
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "pcln-icons": "^2.0.0-beta.3",
-    "styled-components": ">=2.0.0 || >=3.0.0"
+    "styled-components": ">=2.0.0 || >=3.0.0 || >=4.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/core/src/ThemeProvider.js
+++ b/packages/core/src/ThemeProvider.js
@@ -1,14 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled, {
-  ThemeProvider as StyledThemeProvider,
-  injectGlobal
-} from 'styled-components'
+import styled, { ThemeProvider as StyledThemeProvider } from 'styled-components'
 import nextTheme from './theme'
-
-injectGlobal`body {
-  margin: 0;
-}`
 
 export const Base = styled.div`
   font-family: ${props => props.theme.font};


### PR DESCRIPTION
Removed the `injectGlobal` from the ThemeProvider.  It is being [deprecated](https://www.styled-components.com/releases#v3.4.7) as of styled-components 4.0.0.  This opens up the possibility of using styled-components >=4.0.0 as a peer dependency.