### PR TITLE
chore: Update "prepublish" to "prepare" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Priceline Design System",
   "main": "dist/index.js",
   "scripts": {
-    "prepublish": "npm run icons && babel src -d dist --ignore __tests__",
+    "prepare": "npm run icons && babel src -d dist --ignore __tests__",
     "precommit": "lint-staged",
     "start": "start-storybook -p 8000 -c .storybook",
     "icons": "node scripts/parse-icons",


### PR DESCRIPTION
Per [the DEPRECATION NOTE npm PREPUBLISH AND PREPARE doc](https://docs.npmjs.com/misc/scripts#prepublish-and-prepare), it seems to suggest that the favor is on `prepare` over `prepublish`, assuming that backward compatibility to npm 3 is trivial.

Should we update to use `prepare` script?