### PR TITLE
Text line height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-design-system",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-design-system",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Priceline Design System",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Text.js
+++ b/src/Text.js
@@ -1,6 +1,12 @@
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
-import { fontSize, space, color, responsiveStyle } from 'styled-system'
+import {
+  fontSize,
+  lineHeight,
+  space,
+  color,
+  responsiveStyle
+} from 'styled-system'
 import theme from './theme'
 
 export const caps = props =>
@@ -21,7 +27,7 @@ export const italic = props => (props.italic ? { fontStyle: 'italic' } : null)
 const align = responsiveStyle('text-align', 'align')
 
 const Text = styled.div`
-  ${italic} ${fontSize} ${space} ${color} ${caps} ${regular} ${bold} ${align};
+  ${italic} ${fontSize} ${lineHeight} ${space} ${color} ${caps} ${regular} ${bold} ${align};
 `
 
 Text.displayName = 'Text'
@@ -33,11 +39,8 @@ const numberStringOrArray = PropTypes.oneOfType([
 ])
 
 Text.propTypes = {
-  fontSize: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.string,
-    PropTypes.array
-  ]),
+  fontSize: numberStringOrArray,
+  lineHeight: numberStringOrArray,
   align: PropTypes.oneOf(['left', 'center', 'right', 'justify']),
   caps: PropTypes.bool,
   regular: PropTypes.bool,

--- a/src/__tests__/Text.js
+++ b/src/__tests__/Text.js
@@ -55,6 +55,25 @@ describe('Text', () => {
     expect(f6).toHaveStyleRule('font-size', theme.fontSizes[6] + 'px')
   })
 
+  test('lineHeight prop sets line-height', () => {
+    const f0 = renderer.create(<Text lineHeight={0} />).toJSON()
+    const f1 = renderer.create(<Text lineHeight={1} />).toJSON()
+    const f2 = renderer.create(<Text lineHeight={2} />).toJSON()
+    const f3 = renderer.create(<Text lineHeight={3} />).toJSON()
+    const f4 = renderer.create(<Text lineHeight={4} />).toJSON()
+    const f5 = renderer.create(<Text lineHeight={5} />).toJSON()
+    const f6 = renderer.create(<Text lineHeight={6} />).toJSON()
+    const f7 = renderer.create(<Text lineHeight="16px" />).toJSON()
+    expect(f0).toHaveStyleRule('line-height', theme.lineHeights[0])
+    expect(f1).toHaveStyleRule('line-height', theme.lineHeights[1])
+    expect(f2).toHaveStyleRule('line-height', theme.lineHeights[2])
+    expect(f3).toHaveStyleRule('line-height', theme.lineHeights[3])
+    expect(f4).toHaveStyleRule('line-height', theme.lineHeights[4])
+    expect(f5).toHaveStyleRule('line-height', theme.lineHeights[5])
+    expect(f6).toHaveStyleRule('line-height', theme.lineHeights[6])
+    expect(f7).toHaveStyleRule('line-height', '16px')
+  })
+
   test('mt prop sets margin-top', () => {
     const json = renderer.create(<Text mt={2} />).toJSON()
     expect(json).toMatchSnapshot()

--- a/src/__tests__/__snapshots__/theme.js.snap
+++ b/src/__tests__/__snapshots__/theme.js.snap
@@ -117,6 +117,15 @@ Object {
     "caps": "0.025em",
     "normal": "normal",
   },
+  "lineHeights": Array [
+    "12px",
+    "14px",
+    "16px",
+    "20px",
+    "24px",
+    "32px",
+    "48px",
+  ],
   "maxContainerWidth": "1280px",
   "mediaQueries": Array [
     "@media screen and (min-width:32em)",

--- a/src/theme.js
+++ b/src/theme.js
@@ -24,6 +24,15 @@ export const space = [0, 4, 8, 16, 32, 64, 128]
 export const font = `'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif`
 
 export const fontSizes = [12, 14, 16, 20, 24, 32, 48]
+export const lineHeights = [
+  '12px',
+  '14px',
+  '16px',
+  '20px',
+  '24px',
+  '32px',
+  '48px'
+]
 
 export const regular = 400
 export const bold = 600
@@ -165,6 +174,7 @@ const theme = {
   font,
   fontSizes,
   fontWeights,
+  lineHeights,
   letterSpacings,
   regular,
   bold,


### PR DESCRIPTION
naive implementation of allowing lineHeight prop for Text.

@jxnblk I wasn't sure the best way to handle this using `styled-system`, since fontSize is exported with the responsive sizing but lineHeight is not

https://github.com/jxnblk/styled-system/blob/master/src/index.js#L261
vs
https://github.com/jxnblk/styled-system/blob/master/src/index.js#L304