### PR TITLE
Update text align example in docs for Text component

### DIFF
--- a/docs/pages/Text.md
+++ b/docs/pages/Text.md
@@ -9,7 +9,7 @@ Use the `Text` component to control font size, weight, alignment, and color.
 ```
 
 ```.jsx
-<Text textAlign='center'>
+<Text align='center'>
   Centered Text
 </Text>
 ```


### PR DESCRIPTION
Example for centered text didn't match the actual prop name.