### PR TITLE
replace jest deprecated option

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "styled-components": "^3.4.10"
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "./test-setup.js",
+    "setupFilesAfterEnv": [
+      "./test-setup.js"
+    ],
     "coverageReporters": [
       "lcov",
       "html"

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -29,7 +29,9 @@
     "us": "^2.0.0"
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "../../test-setup.js",
+    "setupFilesAfterEnv": [
+      "../../test-setup.js"
+    ],
     "testMatch": [
       "<rootDir>/test/**/*.js"
     ]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,9 @@
     "stylis": "^3.4.9"
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "../../test-setup.js",
+    "setupFilesAfterEnv": [
+      "../../test-setup.js"
+    ],
     "testMatch": [
       "<rootDir>/test/**/*.js"
     ]

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -28,7 +28,9 @@
     "styled-components": ">=3.x || >=4.x"
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "../../test-setup.js",
+    "setupFilesAfterEnv": [
+      "../../test-setup.js"
+    ],
     "testMatch": [
       "<rootDir>/test/**/*.js"
     ]


### PR DESCRIPTION
Replace jest `setupTestFrameworkScriptFile` deprecated option with `setupFilesAfterEnv`

fixes #450