### PR TITLE
Autocomplete Updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6563,9 +6563,9 @@
       }
     },
     "dom-align": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.8.0.tgz",
-      "integrity": "sha512-B85D4ef2Gj5lw0rK0KM2+D5/pH7yqNxg2mB+E8uzFaolpm7RQmsxEfjyEuNiF8UBBkffumYDeKRzTzc3LePP+w=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.8.2.tgz",
+      "integrity": "sha512-17vInOylbB7H4qua7QRsmQT05FFTZemO8BhnOPgF9BPqjAPDyQr/9V8fmJbn05vQ31m2gu3EJSSYN2u94szUZg=="
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -6716,12 +6716,14 @@
       }
     },
     "downshift": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-2.2.3.tgz",
-      "integrity": "sha512-SXFgGq5QYT9mxbaSsYdp4Ng0tP87F5z33PD+tZ2kyK0qIBYd1rcPe90+ykCOYqsWHsb/gcrjaAav2Jpa6qNbQg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-3.2.6.tgz",
+      "integrity": "sha512-g9K3W7D5yS9gnJhPFzfGcABs/Fb01+TON+Eks4gJf3Q+3CnJNzWl+oJeJOiKzB8EnHhttZSy3RhTRgKRzG/Tqg==",
       "requires": {
-        "compute-scroll-into-view": "^1.0.2",
-        "prop-types": "^15.6.0"
+        "@babel/runtime": "^7.1.2",
+        "compute-scroll-into-view": "^1.0.9",
+        "prop-types": "^15.6.0",
+        "react-is": "^16.5.2"
       }
     },
     "duplexer": {
@@ -13724,9 +13726,9 @@
       }
     },
     "rc-slider": {
-      "version": "8.6.5",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-8.6.5.tgz",
-      "integrity": "sha512-/wcfWHbQVu5qiK+nY4a+j/F7JrxPw81UhNARK6iooBNQGsCq0CJjKLCVAOPtDa9QPGNR3l5Kda+nsKJ/rbZNDw==",
+      "version": "8.6.6",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-8.6.6.tgz",
+      "integrity": "sha512-byfnq1LbBFyZ0HURWo22sjeiKIxLyzSnIiNUsUf6SWu1ZhQe/Qt24JnE/ZJsqKoUirXxlX+d577ptfAybZHm+Q==",
       "requires": {
         "babel-runtime": "6.x",
         "classnames": "^2.2.5",
@@ -13734,7 +13736,17 @@
         "rc-tooltip": "^3.7.0",
         "rc-util": "^4.0.4",
         "shallowequal": "^1.0.1",
-        "warning": "^3.0.0"
+        "warning": "^4.0.3"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
       }
     },
     "rc-tooltip": {
@@ -16984,6 +16996,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }

--- a/packages/autocomplete/package-lock.json
+++ b/packages/autocomplete/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
-      "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
+      "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
       "requires": {
         "regenerator-runtime": "^0.12.0"
       }
@@ -40,6 +40,11 @@
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
       "dev": true
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz",
+      "integrity": "sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A=="
+    },
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
@@ -61,6 +66,17 @@
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
         "postcss-value-parser": "^3.3.0"
+      }
+    },
+    "downshift": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-3.2.6.tgz",
+      "integrity": "sha512-g9K3W7D5yS9gnJhPFzfGcABs/Fb01+TON+Eks4gJf3Q+3CnJNzWl+oJeJOiKzB8EnHhttZSy3RhTRgKRzG/Tqg==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "compute-scroll-into-view": "^1.0.9",
+        "prop-types": "^15.6.0",
+        "react-is": "^16.5.2"
       }
     },
     "encoding": {

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -12,7 +12,7 @@
   "author": "Priceline",
   "license": "MIT",
   "dependencies": {
-    "downshift": "^2.2.2",
+    "downshift": "^3.2.6",
     "pcln-design-system": "^2.0.2",
     "prop-types": "^15.7.2",
     "styled-system": "^3.2.1"

--- a/packages/autocomplete/src/index.js
+++ b/packages/autocomplete/src/index.js
@@ -49,7 +49,7 @@ MenuCard.defaultProps = {
 }
 
 const MenuRoot = React.forwardRef((props, ref) => (
-  <MenuCard {...props} innerRef={ref} />
+  <MenuCard {...props} ref={ref} />
 ))
 
 export const Menu = ({ children, ...props }) => (

--- a/packages/autocomplete/src/index.js
+++ b/packages/autocomplete/src/index.js
@@ -49,7 +49,7 @@ MenuCard.defaultProps = {
 }
 
 const MenuRoot = React.forwardRef((props, ref) => (
-  <MenuCard {...props} ref={ref} />
+  <MenuCard {...props} innerRef={ref} />
 ))
 
 export const Menu = ({ children, ...props }) => (

--- a/packages/autocomplete/storybook/Autocomplete.js
+++ b/packages/autocomplete/storybook/Autocomplete.js
@@ -24,7 +24,7 @@ storiesOf('Autocomplete', module).add('default', () => (
           <Menu>
             {cats.map(cat => (
               <Item key={cat} item={cat}>
-                <Icon name="pin" color="blue" mr={2} />
+                <Icon name="Pin" color="blue" mr={2} />
                 <Text fontSize={0}>{cat}</Text>
               </Item>
             ))}


### PR DESCRIPTION
* Precautious update `ref` instead of ~`innerRef`~ in `MenuCard` to avoid warning of deprecated ~`innerRef`~, when `styled-components` upgrades to v4:

<img width="1380" alt="screen shot 2019-03-05 at 8 00 47 pm" src="https://user-images.githubusercontent.com/6441326/53849631-773a7c80-3f86-11e9-8b24-63a978a2372e.png">

* Uptick `downshift`dep of `Autocomplete` to latest version

* Update upper case of 1st letter (per console warning from the `pcln-design-system` v2 requirement) of the `name` prop for the pin icon in `Autocomplete`.