### PR TITLE
Implement support for read-only mode for Input

### DIFF
--- a/packages/autocomplete/test/__snapshots__/index.js.snap
+++ b/packages/autocomplete/test/__snapshots__/index.js.snap
@@ -117,6 +117,7 @@ exports[`Autocomplete renders 1`] = `
     onBlur={[Function]}
     onChange={[Function]}
     onKeyDown={[Function]}
+    readonly={true}
     value=""
   />
   <div

--- a/packages/autocomplete/test/__snapshots__/index.js.snap
+++ b/packages/autocomplete/test/__snapshots__/index.js.snap
@@ -117,7 +117,7 @@ exports[`Autocomplete renders 1`] = `
     onBlur={[Function]}
     onChange={[Function]}
     onKeyDown={[Function]}
-    readonly={true}
+    readonly={null}
     value=""
   />
   <div

--- a/packages/core/src/Input.js
+++ b/packages/core/src/Input.js
@@ -1,4 +1,4 @@
-import styled, { keyframes } from 'styled-components'
+import styled from 'styled-components'
 import { space, themeGet } from 'styled-system'
 import PropTypes from 'prop-types'
 import defaultTheme from './theme'
@@ -17,7 +17,9 @@ const borders = ({ color, theme }) => {
   }
 }
 
-const Input = styled.input`
+const Input = styled.input.attrs({
+  readonly: props => (props.readonly ? 'true' : null)
+})`
   appearance: none;
   display: block;
   width: 100%;
@@ -53,12 +55,14 @@ Input.isField = true
 Input.propTypes = {
   id: PropTypes.string.isRequired,
   color: PropTypes.string,
+  readonly: PropTypes.bool,
   ...borders.propTypes,
   ...space.propTypes
 }
 
 Input.defaultProps = {
-  theme: defaultTheme
+  theme: defaultTheme,
+  readonly: false
 }
 
 export default Input

--- a/packages/core/storybook/Input.js
+++ b/packages/core/storybook/Input.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
-import { Box, Input, Label, theme } from '../src'
+import { Box, Input, Label } from '../src'
 
 storiesOf('Input', module)
   .add(
@@ -12,6 +12,16 @@ storiesOf('Input', module)
         'Simple styled input component that accepts a color and whether or not to show an error container.'
     })(() => <Input my={3} />)
   )
+  .add('Read-only mode', () => (
+    <Box width={400}>
+      <Input
+        mb={3}
+        id="input-read-only"
+        readonly
+        placeholder="Read-only mode"
+      />
+    </Box>
+  ))
   .add('Colors', () => (
     <Box width={400}>
       <Input mb={3} id="input-colors-1" placeholder="No color" />

--- a/packages/core/test/Input.js
+++ b/packages/core/test/Input.js
@@ -21,4 +21,9 @@ describe('Input', () => {
     const json = renderer.create(<Input id={id} fontSize={4} />).toJSON()
     expect(json).toMatchSnapshot()
   })
+  test('it renders an input element with readonly prop', async () => {
+    const json = renderer.create(<Input id={id} readonly />).toJSON()
+    expect(json).toMatchSnapshot()
+    expect(json).toHaveProperty(['props', 'readonly'], 'true')
+  })
 })

--- a/packages/core/test/__snapshots__/FormField.js.snap
+++ b/packages/core/test/__snapshots__/FormField.js.snap
@@ -98,6 +98,7 @@ exports[`FormField renders 1`] = `
     <input
       className="c2"
       id="email"
+      readonly={null}
       style={
         Object {
           "paddingBottom": 8,
@@ -238,6 +239,7 @@ exports[`FormField renders with Icon 1`] = `
       className="c3"
       id="email"
       name="email"
+      readonly={null}
       style={
         Object {
           "paddingBottom": 8,
@@ -378,6 +380,7 @@ exports[`FormField renders with Label autoHide prop 1`] = `
       className="c3"
       id="email"
       name="email"
+      readonly={null}
       style={
         Object {
           "paddingBottom": 14,

--- a/packages/core/test/__snapshots__/IconField.js.snap
+++ b/packages/core/test/__snapshots__/IconField.js.snap
@@ -90,6 +90,7 @@ exports[`IconField renders 1`] = `
     className="c2"
     id="test"
     placeholder="IconField"
+    readonly={null}
     style={
       Object {
         "paddingLeft": 40,

--- a/packages/core/test/__snapshots__/Input.js.snap
+++ b/packages/core/test/__snapshots__/Input.js.snap
@@ -53,6 +53,7 @@ exports[`Input it renders 1`] = `
 <input
   className="c0"
   id="fake-test-id"
+  readonly={null}
 />
 `;
 
@@ -111,6 +112,7 @@ exports[`Input it renders an input element with a really large padding and margi
 <input
   className="c0"
   id="fake-test-id"
+  readonly={null}
 />
 `;
 
@@ -168,6 +170,7 @@ exports[`Input it renders an input element with a red border with a color prop i
   className="c0"
   color="red"
   id="fake-test-id"
+  readonly={null}
 />
 `;
 
@@ -225,5 +228,63 @@ exports[`Input it renders an input element with large text 1`] = `
   className="c0"
   fontSize={4}
   id="fake-test-id"
+  readonly={null}
+/>
+`;
+
+exports[`Input it renders an input element with readonly prop 1`] = `
+.c0 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: block;
+  width: 100%;
+  font-family: inherit;
+  font-size: 14px;
+  color: inherit;
+  background-color: transparent;
+  border-radius: 2px;
+  border-width: 0px;
+  border-style: solid;
+  border-color: #c0cad5;
+  padding-top: 14px;
+  padding-bottom: 14px;
+  padding-left: 12px;
+  padding-right: 12px;
+  margin: 0;
+  border-color: #c0cad5;
+  box-shadow: 0 0 0 1px #c0cad5;
+}
+
+.c0::-webkit-input-placeholder {
+  color: #4f6f8f;
+}
+
+.c0::-moz-placeholder {
+  color: #4f6f8f;
+}
+
+.c0:-ms-input-placeholder {
+  color: #4f6f8f;
+}
+
+.c0::placeholder {
+  color: #4f6f8f;
+}
+
+.c0::-ms-clear {
+  display: none;
+}
+
+.c0:focus {
+  outline: 0;
+  border-color: #007aff;
+  box-shadow: 0 0 0 2px #007aff;
+}
+
+<input
+  className="c0"
+  id="fake-test-id"
+  readonly="true"
 />
 `;


### PR DESCRIPTION
* Add `readonly` prop support for `Input`
  * `readonly` prop for `readonly` attribute with `true` string value
* Write test

<img width="712" alt="Screen Shot 2019-04-02 at 2 48 13 PM" src="https://user-images.githubusercontent.com/6441326/55428811-f0ae9600-5557-11e9-8418-0e47c1864d6d.png">

<img width="942" alt="Screen Shot 2019-04-02 at 3 03 58 PM" src="https://user-images.githubusercontent.com/6441326/55429165-d1643880-5558-11e9-82d1-b43a63b09be2.png">

