### PR TITLE
fix: add isIcon flag to Icon in pcln-icons to support FormField in core

### DIFF
--- a/packages/icons/src/Icon.js
+++ b/packages/icons/src/Icon.js
@@ -48,6 +48,7 @@ Icon.defaultProps = {
 }
 
 Icon.displayName = 'Icon'
+Icon.isIcon = true
 
 Icon.propTypes = {
   name: (props, key, componentName) => {


### PR DESCRIPTION
`FormField` logic at [L19}(https://github.com/pricelinelabs/design-system/blob/master/packages/core/src/FormField.js#L19) would miss the truthy value by `isIcon` flag to enter the `if` block to run through the logic to render an icon correctly:

https://github.com/pricelinelabs/design-system/blob/2bed46de82d973627283fd6840ec252cd79e6fda/packages/core/src/FormField.js#L19

```jsx
<FormField … >
  <Icon … >
  …
</FormField>
```

This PR fixes by adding the `isIcon` flag to support `FormField` logic, similar to the [`Icon` in core](https://github.com/pricelinelabs/design-system/blob/master/packages/core/src/Icon.js#L2), which will be deprecated:

https://github.com/pricelinelabs/design-system/blob/2bed46de82d973627283fd6840ec252cd79e6fda/packages/core/src/Icon.js#L2