### PR TITLE
fix: correct width prop in Banner

### DIFF
--- a/packages/core/src/Banner.js
+++ b/packages/core/src/Banner.js
@@ -59,7 +59,7 @@ const Banner = props => {
         {!!icon && !!props.showIcon && (
           <Icon name={icon} mr={2} size={24} mt="-2px" />
         )}
-        <Box w={1}>
+        <Box width={1}>
           <Text textAlign={props.textAlign}>
             <Heading.h5>{props.header}</Heading.h5>
             <Text.span fontSize={1}>{props.text}</Text.span>

--- a/packages/core/src/Banner.js
+++ b/packages/core/src/Banner.js
@@ -61,7 +61,7 @@ const Banner = props => {
         )}
         <Box width={1}>
           <Text textAlign={props.textAlign}>
-            <Heading.h5>{props.header}</Heading.h5>
+            <Heading.h5 textStyle="display2">{props.header}</Heading.h5>
             <Text.span fontSize={1}>{props.text}</Text.span>
             {props.children}
           </Text>

--- a/packages/core/test/__snapshots__/Banner.js.snap
+++ b/packages/core/test/__snapshots__/Banner.js.snap
@@ -34,7 +34,7 @@ exports[`Banner accepts non-preset colors 1`] = `
 }
 
 .c4 {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
   margin: 0px;
@@ -109,7 +109,7 @@ exports[`Banner renders content from children props 1`] = `
 }
 
 .c5 {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
   margin: 0px;
@@ -202,7 +202,7 @@ exports[`Banner renders with blue bg 1`] = `
 }
 
 .c5 {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
   margin: 0px;
@@ -292,7 +292,7 @@ exports[`Banner renders with custom iconName and size 1`] = `
 }
 
 .c5 {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
   margin: 0px;
@@ -382,7 +382,7 @@ exports[`Banner renders with green bg 1`] = `
 }
 
 .c5 {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
   margin: 0px;
@@ -472,7 +472,7 @@ exports[`Banner renders with lightBlue bg 1`] = `
 }
 
 .c5 {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
   margin: 0px;
@@ -562,7 +562,7 @@ exports[`Banner renders with lightGreen bg 1`] = `
 }
 
 .c5 {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
   margin: 0px;
@@ -652,7 +652,7 @@ exports[`Banner renders with lightRed bg 1`] = `
 }
 
 .c5 {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
   margin: 0px;
@@ -742,7 +742,7 @@ exports[`Banner renders with no props other than theme 1`] = `
 }
 
 .c5 {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
   margin: 0px;
@@ -832,7 +832,7 @@ exports[`Banner renders with orange bg 1`] = `
 }
 
 .c5 {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
   margin: 0px;
@@ -922,7 +922,7 @@ exports[`Banner renders with red bg 1`] = `
 }
 
 .c5 {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
   margin: 0px;
@@ -1012,7 +1012,7 @@ exports[`Banner renders with text node 1`] = `
 }
 
 .c5 {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
   margin: 0px;
@@ -1110,7 +1110,7 @@ exports[`Banner renders with text string 1`] = `
 }
 
 .c5 {
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.25;
   margin: 0px;

--- a/packages/core/test/__snapshots__/Banner.js.snap
+++ b/packages/core/test/__snapshots__/Banner.js.snap
@@ -1,70 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Banner accepts non-preset colors 1`] = `
+.c2 {
+  width: 100%;
+}
+
 .c0 {
   background-color: #4f6f8f;
-  text-align: left;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c2 {
-  text-align: left;
-}
-
-.c4 {
-  font-size: 14px;
-}
-
-.c3 {
-  font-size: 24px;
-  font-weight: 700;
-  line-height: 1.25;
-  margin: 0px;
-}
-
-<div
-  className="c0"
->
-  <div
-    className="c1"
-  >
-    <div
-      className=""
-    >
-      <div
-        className="c2"
-      >
-        <h5
-          className="c3"
-        />
-        <span
-          className="c4"
-          fontSize={1}
-        />
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Banner renders content from children props 1`] = `
-.c0 {
-  color: #fff;
-  background-color: #0a0;
   text-align: left;
 }
 
@@ -91,6 +33,73 @@ exports[`Banner renders content from children props 1`] = `
   font-size: 14px;
 }
 
+.c4 {
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1.25;
+  margin: 0px;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1"
+  >
+    <div
+      className="c2"
+      width={1}
+    >
+      <div
+        className="c3"
+      >
+        <h5
+          className="c4"
+        />
+        <span
+          className="c5"
+          fontSize={1}
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Banner renders content from children props 1`] = `
+.c0 {
+  color: #fff;
+  background-color: #0a0;
+  text-align: left;
+}
+
+.c3 {
+  width: 100%;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c4 {
+  text-align: left;
+}
+
+.c6 {
+  font-size: 14px;
+}
+
 .c2 {
   -webkit-flex: none;
   -ms-flex: none;
@@ -99,7 +108,7 @@ exports[`Banner renders content from children props 1`] = `
   margin-top: -2px;
 }
 
-.c4 {
+.c5 {
   font-size: 24px;
   font-weight: 700;
   line-height: 1.25;
@@ -128,16 +137,17 @@ exports[`Banner renders content from children props 1`] = `
       />
     </svg>
     <div
-      className=""
+      className="c3"
+      width={1}
     >
       <div
-        className="c3"
+        className="c4"
       >
         <h5
-          className="c4"
+          className="c5"
         />
         <span
-          className="c5"
+          className="c6"
           fontSize={1}
         />
         <span>
@@ -150,6 +160,10 @@ exports[`Banner renders content from children props 1`] = `
 `;
 
 exports[`Banner renders with blue bg 1`] = `
+.c3 {
+  width: 100%;
+}
+
 .c0 {
   color: #fff;
   background-color: #007aff;
@@ -171,11 +185,11 @@ exports[`Banner renders with blue bg 1`] = `
   justify-content: space-between;
 }
 
-.c3 {
+.c4 {
   text-align: left;
 }
 
-.c5 {
+.c6 {
   font-size: 14px;
 }
 
@@ -187,7 +201,7 @@ exports[`Banner renders with blue bg 1`] = `
   margin-top: -2px;
 }
 
-.c4 {
+.c5 {
   font-size: 24px;
   font-weight: 700;
   line-height: 1.25;
@@ -216,16 +230,17 @@ exports[`Banner renders with blue bg 1`] = `
       />
     </svg>
     <div
-      className=""
+      className="c3"
+      width={1}
     >
       <div
-        className="c3"
+        className="c4"
       >
         <h5
-          className="c4"
+          className="c5"
         />
         <span
-          className="c5"
+          className="c6"
           fontSize={1}
         />
       </div>
@@ -239,6 +254,10 @@ exports[`Banner renders with custom iconName and size 1`] = `
   color: #fff;
   background-color: #0a0;
   text-align: left;
+}
+
+.c3 {
+  width: 100%;
 }
 
 .c1 {
@@ -256,11 +275,11 @@ exports[`Banner renders with custom iconName and size 1`] = `
   justify-content: space-between;
 }
 
-.c3 {
+.c4 {
   text-align: left;
 }
 
-.c5 {
+.c6 {
   font-size: 14px;
 }
 
@@ -272,7 +291,7 @@ exports[`Banner renders with custom iconName and size 1`] = `
   margin-top: -2px;
 }
 
-.c4 {
+.c5 {
   font-size: 24px;
   font-weight: 700;
   line-height: 1.25;
@@ -301,16 +320,17 @@ exports[`Banner renders with custom iconName and size 1`] = `
       />
     </svg>
     <div
-      className=""
+      className="c3"
+      width={1}
     >
       <div
-        className="c3"
+        className="c4"
       >
         <h5
-          className="c4"
+          className="c5"
         />
         <span
-          className="c5"
+          className="c6"
           fontSize={1}
         />
       </div>
@@ -324,6 +344,10 @@ exports[`Banner renders with green bg 1`] = `
   color: #fff;
   background-color: #0a0;
   text-align: left;
+}
+
+.c3 {
+  width: 100%;
 }
 
 .c1 {
@@ -341,11 +365,11 @@ exports[`Banner renders with green bg 1`] = `
   justify-content: space-between;
 }
 
-.c3 {
+.c4 {
   text-align: left;
 }
 
-.c5 {
+.c6 {
   font-size: 14px;
 }
 
@@ -357,7 +381,7 @@ exports[`Banner renders with green bg 1`] = `
   margin-top: -2px;
 }
 
-.c4 {
+.c5 {
   font-size: 24px;
   font-weight: 700;
   line-height: 1.25;
@@ -386,16 +410,17 @@ exports[`Banner renders with green bg 1`] = `
       />
     </svg>
     <div
-      className=""
+      className="c3"
+      width={1}
     >
       <div
-        className="c3"
+        className="c4"
       >
         <h5
-          className="c4"
+          className="c5"
         />
         <span
-          className="c5"
+          className="c6"
           fontSize={1}
         />
       </div>
@@ -405,6 +430,10 @@ exports[`Banner renders with green bg 1`] = `
 `;
 
 exports[`Banner renders with lightBlue bg 1`] = `
+.c3 {
+  width: 100%;
+}
+
 .c0 {
   color: #049;
   background-color: #e8f2ff;
@@ -426,11 +455,11 @@ exports[`Banner renders with lightBlue bg 1`] = `
   justify-content: space-between;
 }
 
-.c3 {
+.c4 {
   text-align: left;
 }
 
-.c5 {
+.c6 {
   font-size: 14px;
 }
 
@@ -442,7 +471,7 @@ exports[`Banner renders with lightBlue bg 1`] = `
   margin-top: -2px;
 }
 
-.c4 {
+.c5 {
   font-size: 24px;
   font-weight: 700;
   line-height: 1.25;
@@ -471,16 +500,17 @@ exports[`Banner renders with lightBlue bg 1`] = `
       />
     </svg>
     <div
-      className=""
+      className="c3"
+      width={1}
     >
       <div
-        className="c3"
+        className="c4"
       >
         <h5
-          className="c4"
+          className="c5"
         />
         <span
-          className="c5"
+          className="c6"
           fontSize={1}
         />
       </div>
@@ -490,6 +520,10 @@ exports[`Banner renders with lightBlue bg 1`] = `
 `;
 
 exports[`Banner renders with lightGreen bg 1`] = `
+.c3 {
+  width: 100%;
+}
+
 .c0 {
   color: #060;
   background-color: #ecf7ec;
@@ -511,11 +545,11 @@ exports[`Banner renders with lightGreen bg 1`] = `
   justify-content: space-between;
 }
 
-.c3 {
+.c4 {
   text-align: left;
 }
 
-.c5 {
+.c6 {
   font-size: 14px;
 }
 
@@ -527,7 +561,7 @@ exports[`Banner renders with lightGreen bg 1`] = `
   margin-top: -2px;
 }
 
-.c4 {
+.c5 {
   font-size: 24px;
   font-weight: 700;
   line-height: 1.25;
@@ -556,16 +590,17 @@ exports[`Banner renders with lightGreen bg 1`] = `
       />
     </svg>
     <div
-      className=""
+      className="c3"
+      width={1}
     >
       <div
-        className="c3"
+        className="c4"
       >
         <h5
-          className="c4"
+          className="c5"
         />
         <span
-          className="c5"
+          className="c6"
           fontSize={1}
         />
       </div>
@@ -575,6 +610,10 @@ exports[`Banner renders with lightGreen bg 1`] = `
 `;
 
 exports[`Banner renders with lightRed bg 1`] = `
+.c3 {
+  width: 100%;
+}
+
 .c0 {
   color: #800;
   background-color: #fbebeb;
@@ -596,11 +635,11 @@ exports[`Banner renders with lightRed bg 1`] = `
   justify-content: space-between;
 }
 
-.c3 {
+.c4 {
   text-align: left;
 }
 
-.c5 {
+.c6 {
   font-size: 14px;
 }
 
@@ -612,7 +651,7 @@ exports[`Banner renders with lightRed bg 1`] = `
   margin-top: -2px;
 }
 
-.c4 {
+.c5 {
   font-size: 24px;
   font-weight: 700;
   line-height: 1.25;
@@ -641,16 +680,17 @@ exports[`Banner renders with lightRed bg 1`] = `
       />
     </svg>
     <div
-      className=""
+      className="c3"
+      width={1}
     >
       <div
-        className="c3"
+        className="c4"
       >
         <h5
-          className="c4"
+          className="c5"
         />
         <span
-          className="c5"
+          className="c6"
           fontSize={1}
         />
       </div>
@@ -664,6 +704,10 @@ exports[`Banner renders with no props other than theme 1`] = `
   color: #fff;
   background-color: #0a0;
   text-align: left;
+}
+
+.c3 {
+  width: 100%;
 }
 
 .c1 {
@@ -681,11 +725,11 @@ exports[`Banner renders with no props other than theme 1`] = `
   justify-content: space-between;
 }
 
-.c3 {
+.c4 {
   text-align: left;
 }
 
-.c5 {
+.c6 {
   font-size: 14px;
 }
 
@@ -697,7 +741,7 @@ exports[`Banner renders with no props other than theme 1`] = `
   margin-top: -2px;
 }
 
-.c4 {
+.c5 {
   font-size: 24px;
   font-weight: 700;
   line-height: 1.25;
@@ -726,16 +770,17 @@ exports[`Banner renders with no props other than theme 1`] = `
       />
     </svg>
     <div
-      className=""
+      className="c3"
+      width={1}
     >
       <div
-        className="c3"
+        className="c4"
       >
         <h5
-          className="c4"
+          className="c5"
         />
         <span
-          className="c5"
+          className="c6"
           fontSize={1}
         />
       </div>
@@ -745,6 +790,10 @@ exports[`Banner renders with no props other than theme 1`] = `
 `;
 
 exports[`Banner renders with orange bg 1`] = `
+.c3 {
+  width: 100%;
+}
+
 .c0 {
   color: #fff;
   background-color: #f68013;
@@ -766,11 +815,11 @@ exports[`Banner renders with orange bg 1`] = `
   justify-content: space-between;
 }
 
-.c3 {
+.c4 {
   text-align: left;
 }
 
-.c5 {
+.c6 {
   font-size: 14px;
 }
 
@@ -782,7 +831,7 @@ exports[`Banner renders with orange bg 1`] = `
   margin-top: -2px;
 }
 
-.c4 {
+.c5 {
   font-size: 24px;
   font-weight: 700;
   line-height: 1.25;
@@ -811,16 +860,17 @@ exports[`Banner renders with orange bg 1`] = `
       />
     </svg>
     <div
-      className=""
+      className="c3"
+      width={1}
     >
       <div
-        className="c3"
+        className="c4"
       >
         <h5
-          className="c4"
+          className="c5"
         />
         <span
-          className="c5"
+          className="c6"
           fontSize={1}
         />
       </div>
@@ -830,6 +880,10 @@ exports[`Banner renders with orange bg 1`] = `
 `;
 
 exports[`Banner renders with red bg 1`] = `
+.c3 {
+  width: 100%;
+}
+
 .c0 {
   color: #fff;
   background-color: #c00;
@@ -851,11 +905,11 @@ exports[`Banner renders with red bg 1`] = `
   justify-content: space-between;
 }
 
-.c3 {
+.c4 {
   text-align: left;
 }
 
-.c5 {
+.c6 {
   font-size: 14px;
 }
 
@@ -867,7 +921,7 @@ exports[`Banner renders with red bg 1`] = `
   margin-top: -2px;
 }
 
-.c4 {
+.c5 {
   font-size: 24px;
   font-weight: 700;
   line-height: 1.25;
@@ -896,16 +950,17 @@ exports[`Banner renders with red bg 1`] = `
       />
     </svg>
     <div
-      className=""
+      className="c3"
+      width={1}
     >
       <div
-        className="c3"
+        className="c4"
       >
         <h5
-          className="c4"
+          className="c5"
         />
         <span
-          className="c5"
+          className="c6"
           fontSize={1}
         />
       </div>
@@ -919,6 +974,10 @@ exports[`Banner renders with text node 1`] = `
   color: #fff;
   background-color: #0a0;
   text-align: left;
+}
+
+.c3 {
+  width: 100%;
 }
 
 .c1 {
@@ -936,11 +995,11 @@ exports[`Banner renders with text node 1`] = `
   justify-content: space-between;
 }
 
-.c3 {
+.c4 {
   text-align: left;
 }
 
-.c5 {
+.c6 {
   font-size: 14px;
 }
 
@@ -952,7 +1011,7 @@ exports[`Banner renders with text node 1`] = `
   margin-top: -2px;
 }
 
-.c4 {
+.c5 {
   font-size: 24px;
   font-weight: 700;
   line-height: 1.25;
@@ -981,18 +1040,19 @@ exports[`Banner renders with text node 1`] = `
       />
     </svg>
     <div
-      className=""
+      className="c3"
+      width={1}
     >
       <div
-        className="c3"
+        className="c4"
       >
         <h5
-          className="c4"
+          className="c5"
         >
           Header
         </h5>
         <span
-          className="c5"
+          className="c6"
           fontSize={1}
         >
           <div
@@ -1014,6 +1074,10 @@ exports[`Banner renders with text string 1`] = `
   text-align: left;
 }
 
+.c3 {
+  width: 100%;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1029,11 +1093,11 @@ exports[`Banner renders with text string 1`] = `
   justify-content: space-between;
 }
 
-.c3 {
+.c4 {
   text-align: left;
 }
 
-.c5 {
+.c6 {
   font-size: 14px;
 }
 
@@ -1045,7 +1109,7 @@ exports[`Banner renders with text string 1`] = `
   margin-top: -2px;
 }
 
-.c4 {
+.c5 {
   font-size: 24px;
   font-weight: 700;
   line-height: 1.25;
@@ -1074,18 +1138,19 @@ exports[`Banner renders with text string 1`] = `
       />
     </svg>
     <div
-      className=""
+      className="c3"
+      width={1}
     >
       <div
-        className="c3"
+        className="c4"
       >
         <h5
-          className="c4"
+          className="c5"
         >
           Header
         </h5>
         <span
-          className="c5"
+          className="c6"
           fontSize={1}
         >
           Text


### PR DESCRIPTION
Fix the legacy ~`w`~ to v2 `width` in `Banner`.

https://github.com/pricelinelabs/design-system/blob/162128a7099245e509f47c679a862ae34a22ab07/packages/core/src/Banner.js#L62

Fix the legacy `Heading.h5` style to use `textStyle="display2"` from v2.

https://github.com/pricelinelabs/design-system/blob/162128a7099245e509f47c679a862ae34a22ab07/packages/core/src/Banner.js#L64