### PR TITLE
fix: clean up console warnings Icon name's casing

### DIFF
--- a/packages/core/src/Checkbox.js
+++ b/packages/core/src/Checkbox.js
@@ -10,8 +10,8 @@ const Checkbox = props => {
   return (
     <CheckBoxWrapper disabled={disabled}>
       <StyledInput type="checkbox" {...props} />
-      <Icon name="boxChecked" size={size} data-name="checked" />
-      <Icon name="boxEmpty" size={size} data-name="empty" />
+      <Icon name="BoxChecked" size={size} data-name="checked" />
+      <Icon name="BoxEmpty" size={size} data-name="empty" />
     </CheckBoxWrapper>
   )
 }

--- a/packages/core/src/CloseButton.js
+++ b/packages/core/src/CloseButton.js
@@ -3,7 +3,7 @@ import IconButton from './IconButton'
 import PropTypes from 'prop-types'
 import theme from './theme'
 
-const CloseButton = props => <IconButton {...props} name="close" />
+const CloseButton = props => <IconButton {...props} name="Close" />
 
 CloseButton.defaultProps = {
   size: 24,

--- a/packages/core/src/Select.js
+++ b/packages/core/src/Select.js
@@ -44,7 +44,7 @@ SelectBase.propTypes = {
 const Select = styled(props => (
   <Flex width={1} alignItems="center">
     <SelectBase {...props} />
-    <ClickableIcon ml={-32} name="chevronDown" color="gray" />
+    <ClickableIcon ml={-32} name="ChevronDown" color="gray" />
   </Flex>
 ))``
 

--- a/packages/core/storybook/Absolute.js
+++ b/packages/core/storybook/Absolute.js
@@ -44,7 +44,7 @@ storiesOf('Absolute', module)
           vel sollicitudin lectus viverra. Curabitur sit amet fringilla velit.
         </Text>
         <Absolute top="10px" right="10px">
-          <Icon name="close" color="gray" size={24} />
+          <Icon name="close" color="Gray" size={24} />
         </Absolute>
       </Relative>
     </Card>

--- a/packages/core/storybook/Flag.js
+++ b/packages/core/storybook/Flag.js
@@ -70,7 +70,7 @@ storiesOf('Flag', module)
       <Card pb={3}>
         <Flag mt={2}>
           <Flex>
-            <Icon size={14} mr={1} name="loyalty" />
+            <Icon size={14} mr={1} name="Loyalty" />
             <Text>Hello World</Text>
           </Flex>
         </Flag>

--- a/packages/core/storybook/FormField.js
+++ b/packages/core/storybook/FormField.js
@@ -16,7 +16,7 @@ storiesOf('FormField', module)
   .add('with Icon', () => (
     <FormField>
       <Label htmlFor="demo">Email Address</Label>
-      <Icon name="email" color="blue" />
+      <Icon name="Email" color="blue" />
       <Input id="demo" name="demo" defaultValue="hello@example.com" />
     </FormField>
   ))
@@ -65,13 +65,13 @@ storiesOf('FormField', module)
         placeholder="hello@example.com"
         value="hello@example.com"
       />
-      <Icon name="check" color="green" />
+      <Icon name="Check" color="green" />
     </FormField>
   ))
   .add('with Select', () => (
     <FormField>
       <Label htmlFor="demo">State</Label>
-      <Icon name="pin" color="blue" />
+      <Icon name="Pin" color="blue" />
       <Select id="demo" name="demo">
         <option>New York</option>
         <option>New Jersey</option>
@@ -87,7 +87,7 @@ storiesOf('FormField', module)
         placeholder="hello@example.com"
         color="green"
       />
-      <Icon name="success" color="green" />
+      <Icon name="Success" color="green" />
     </FormField>
   ))
   .add('with error Tooltip', () => (
@@ -101,7 +101,7 @@ storiesOf('FormField', module)
           aria-describedby="demo-error"
           color="red"
         />
-        <Icon name="warning" color="red" />
+        <Icon name="Warning" color="red" />
       </FormField>
       <Tooltip id="demo-error" right color="white" bg="red">
         Email address is required

--- a/packages/core/storybook/IconButton.js
+++ b/packages/core/storybook/IconButton.js
@@ -4,13 +4,13 @@ import { action } from '@storybook/addon-actions'
 import { IconButton } from '../src'
 
 storiesOf('IconButton', module)
-  .add('default', () => <IconButton name="calendar" title="Choose date" />)
+  .add('default', () => <IconButton name="Calendar" title="Choose date" />)
   .add('with color', () => (
-    <IconButton name="calendar" color="blue" title="Choose date" />
+    <IconButton name="Calendar" color="blue" title="Choose date" />
   ))
   .add('with size', () => (
-    <IconButton name="calendar" size={64} title="Choose date" />
+    <IconButton name="Calendar" size={64} title="Choose date" />
   ))
   .add('with other elements', () => (
-    <IconButton name="calendar" size={64} title="Choose date" />
+    <IconButton name="Calendar" size={64} title="Choose date" />
   ))

--- a/packages/core/storybook/IconField.js
+++ b/packages/core/storybook/IconField.js
@@ -5,26 +5,26 @@ import { IconField, Input, Select, Icon } from '../src'
 storiesOf('IconField', module)
   .add('Icon and Input', () => (
     <IconField>
-      <Icon name="calendar" color="blue" />
+      <Icon name="Calendar" color="blue" />
       <Input placeholder="Choose Date" />
     </IconField>
   ))
   .add('Input and Icon', () => (
     <IconField>
       <Input placeholder="Choose Date" />
-      <Icon name="calendar" color="blue" />
+      <Icon name="Calendar" color="blue" />
     </IconField>
   ))
   .add('Icon, Input, and Icon', () => (
     <IconField>
-      <Icon name="calendar" color="blue" />
+      <Icon name="Calendar" color="blue" />
       <Input placeholder="Choose Date" />
-      <Icon name="check" color="green" />
+      <Icon name="Check" color="green" />
     </IconField>
   ))
   .add('Icon and Select', () => (
     <IconField>
-      <Icon name="calendar" color="blue" />
+      <Icon name="Calendar" color="blue" />
       <Select>
         <option>Choose Date</option>
         <option>January 2019</option>

--- a/packages/core/storybook/InputGroup.js
+++ b/packages/core/storybook/InputGroup.js
@@ -16,20 +16,20 @@ storiesOf('InputGroup', module)
     <InputGroup>
       <InputField>
         <Label>Where from?</Label>
-        <Icon name="departure" color="blue" />
+        <Icon name="Departure" color="blue" />
         <Input placeholder="Where from?" />
       </InputField>
       <Text color="gray">–</Text>
       <InputField>
         <Label>Where to?</Label>
-        <Icon name="arrival" color="blue" />
+        <Icon name="Arrival" color="blue" />
         <Input placeholder="Where to?" />
       </InputField>
     </InputGroup>
   ))
   .add('date input alternative', () => (
     <InputGroup>
-      <Icon name="calendar" color="blue" ml={2} />
+      <Icon name="Calendar" color="blue" ml={2} />
       <InputField>
         <Label>Where from?</Label>
         <Input placeholder="Where from?" />

--- a/packages/core/storybook/Layouts.js
+++ b/packages/core/storybook/Layouts.js
@@ -46,7 +46,7 @@ storiesOf('Layout Examples', module)
   ))
   .add('Navbar', () => (
     <Flex p={2} alignItems="center" color="white" bg="blue">
-      <Icon name="hotel" mr={2} />
+      <Icon name="Hotel" mr={2} />
       <Text bold mx={2}>
         Hello
       </Text>

--- a/packages/core/storybook/Relative.js
+++ b/packages/core/storybook/Relative.js
@@ -23,7 +23,7 @@ storiesOf('Relative', module)
           vel sollicitudin lectus viverra. Curabitur sit amet fringilla velit.
         </Text>
         <Absolute top="10px" right="10px">
-          <Icon name="close" color="gray" size={24} />
+          <Icon name="Close" color="gray" size={24} />
         </Absolute>
       </Relative>
     </Card>

--- a/packages/core/storybook/Stamp.js
+++ b/packages/core/storybook/Stamp.js
@@ -18,19 +18,19 @@ storiesOf('Stamp', module)
         default stamp
       </Stamp>
       <Stamp color="blue" mr={2}>
-        <Icon name="pin" size={16} mr={1} /> top location
+        <Icon name="Pin" size={16} mr={1} /> top location
       </Stamp>
       <Stamp color="green" mr={2}>
-        <Icon name="discount" size={16} mr={1} /> lowest price
+        <Icon name="Discount" size={16} mr={1} /> lowest price
       </Stamp>
       <Stamp color="red" mr={2}>
         <Icon name="clock" size={16} mr={1} /> just booked
       </Stamp>
       <Stamp color="orange" mr={2}>
-        <Icon name="earlyBird" size={16} mr={1} /> early bird flight
+        <Icon name="EarlyBird" size={16} mr={1} /> early bird flight
       </Stamp>
       <Stamp color="purple" mr={2}>
-        <Icon name="trendingUp" size={16} mr={1} /> top booked hotel
+        <Icon name="TrendingUp" size={16} mr={1} /> top booked hotel
       </Stamp>
     </div>
   ))

--- a/packages/core/test/Absolute.js
+++ b/packages/core/test/Absolute.js
@@ -18,7 +18,7 @@ describe('Absolute', () => {
     const json = renderer.create(
       <Absolute top={10} left={0}>
         <Flag>
-          <Icon name="coupon" /> <Text.span>EXCLUSIVE</Text.span>
+          <Icon name="Coupon" /> <Text.span>EXCLUSIVE</Text.span>
         </Flag>
       </Absolute>
     ).toJSON

--- a/packages/core/test/FormField.js
+++ b/packages/core/test/FormField.js
@@ -27,7 +27,7 @@ describe('FormField', () => {
       .create(
         <FormField>
           <Label>Email Address</Label>
-          <Icon name="email" />
+          <Icon name="Email" />
           <Input name="email" />
         </FormField>
       )
@@ -50,7 +50,7 @@ describe('FormField', () => {
     const json = renderer
       .create(
         <FormField>
-          <Icon name="email" />
+          <Icon name="Email" />
           <Select />
         </FormField>
       )
@@ -63,7 +63,7 @@ describe('FormField', () => {
       .create(
         <FormField>
           <Label autoHide>Email</Label>
-          <Icon name="email" />
+          <Icon name="Email" />
           <Input name="email" />
         </FormField>
       )
@@ -76,7 +76,7 @@ describe('FormField', () => {
       .create(
         <FormField>
           <Label autoHide>Email</Label>
-          <Icon name="email" />
+          <Icon name="Email" />
           <Input name="email" value="hello@example.com" />
         </FormField>
       )

--- a/packages/core/test/IconField.js
+++ b/packages/core/test/IconField.js
@@ -6,7 +6,7 @@ describe('IconField', () => {
   test('renders', () => {
     const json = TestRenderer.create(
       <IconField>
-        <Icon name="calendar" />
+        <Icon name="Calendar" />
         <Input id="test" placeholder="IconField" />
       </IconField>
     ).toJSON()
@@ -25,7 +25,7 @@ describe('IconField', () => {
   test('adds styles to icons', () => {
     const json = TestRenderer.create(
       <IconField>
-        <Icon name="calendar" />
+        <Icon name="Calendar" />
         <Input id="test" />
       </IconField>
     ).toJSON()
@@ -39,7 +39,7 @@ describe('IconField', () => {
     const json = TestRenderer.create(
       <IconField>
         <Input id="test" />
-        <Icon name="calendar" />
+        <Icon name="Calendar" />
       </IconField>
     ).toJSON()
     const [input, icon] = json.children
@@ -51,7 +51,7 @@ describe('IconField', () => {
   test('adds styles to the form field', () => {
     const json = TestRenderer.create(
       <IconField>
-        <Icon name="calendar" />
+        <Icon name="Calendar" />
         <Input id="test" />
       </IconField>
     ).toJSON()

--- a/packages/core/test/Relative.js
+++ b/packages/core/test/Relative.js
@@ -18,7 +18,7 @@ describe('Relative', () => {
     const json = renderer.create(
       <Relative top={10} left={0}>
         <Absolute top={10} right={0} zIndex={2}>
-          <Icon name="coupon" />
+          <Icon name="Coupon" />
           <Text.span>EXCLUSIVE</Text.span>
         </Absolute>
       </Relative>

--- a/packages/icons/test/index.js
+++ b/packages/icons/test/index.js
@@ -27,7 +27,7 @@ describe('Icon', () => {
   })
 
   test('renders null for missing icons', () => {
-    const json = TestRenderer.create(<Icon name="foo" />).toJSON()
+    const json = TestRenderer.create(<Icon name="Foo" />).toJSON()
     expect(json).toBe(null)
   })
 


### PR DESCRIPTION
Fix the first letter to upper case for all the `Icon` usages in core to kill the undesired console warnings, in sake of improving DX.