### PR TITLE
fix(popover-dependency): Update dependencies of pcln-popover

### DIFF
--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -21,7 +21,6 @@
     ]
   },
   "dependencies": {
-    "pcln-design-system": "^2.0.4",
     "react-popper": "^1.3.3"
   },
   "peerDependencies": {
@@ -34,6 +33,7 @@
     "@babel/plugin-transform-runtime": "^7.4.4",
     "@reach/component-component": "^0.1.1",
     "jest": "^24.1.0",
+    "pcln-design-system": "^2.0.4",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-test-renderer": "^16.8.6",


### PR DESCRIPTION
Move pcln-design-system from a dependency to a devDependency
It is already defined as a peerDependency
The version of pcln-design-system should be up to the consumer