### PR TITLE
fix: Tab index issue prevents focus to be moved around modal

### DIFF
--- a/packages/modal/src/Modal.js
+++ b/packages/modal/src/Modal.js
@@ -191,7 +191,6 @@ const Modal = ({
                       data-testid="pcln-modal-close"
                       header={header}
                       onClick={onClose}
-                      tabIndex="1"
                     />
                   )}
                   {children}

--- a/packages/modal/src/ModalHeader.js
+++ b/packages/modal/src/ModalHeader.js
@@ -25,7 +25,7 @@ const ModalHeader = ({ bg, color, onClose, title }) => (
         {title}
       </Text>
     )}
-    {onClose && <StyledCloseButton onClick={onClose} ml="auto" tabIndex="1" />}
+    {onClose && <StyledCloseButton onClick={onClose} ml="auto" />}
   </HeaderWrapper>
 )
 

--- a/packages/modal/storybook/Modal.js
+++ b/packages/modal/storybook/Modal.js
@@ -41,7 +41,7 @@ class ModalStory extends React.Component {
           {...this.props}
         >
           <div style={{ height: '1000px' }}>
-            Content with 1000px height<button tabIndex="1">Some action</button>
+            Content with 1000px height<button>Some action</button>
           </div>
         </StyledModal>
       </div>

--- a/packages/modal/test/__snapshots__/Headers.js.snap
+++ b/packages/modal/test/__snapshots__/Headers.js.snap
@@ -105,7 +105,6 @@ exports[`ModalHeader render 1`] = `
     <button
       class="c4 c5 c6"
       style="height: 24px;"
-      tabindex="1"
       title="close"
     >
       <svg


### PR DESCRIPTION
This fixes the issue where `tabIndex` is stuck on the close button on the modal and doesn't allow for other tab-able items to be focused. This issue is caused by a `tabIndex="1"`, which prevents other actionable items to be focused, since they all have a `tabIndex="0"` by default.