### PR TITLE
Allow Icon Button in Form Field

### DIFF
--- a/packages/core/src/IconButton.js
+++ b/packages/core/src/IconButton.js
@@ -30,5 +30,6 @@ IconButton.displayName = 'IconButton'
 IconButton.defaultProps = {
   theme: theme
 }
+IconButton.isIconButton = true
 
 export default IconButton

--- a/packages/core/src/IconField.js
+++ b/packages/core/src/IconField.js
@@ -2,18 +2,20 @@ import React from 'react'
 import Flex from './Flex'
 
 const IconField = props => {
+  const isIcon = item => item.type.isIcon || item.type.isIconButton
+
   const children = React.Children.toArray(props.children).filter(
-    child => child.type.isField || child.type.isIcon
+    child => child.type.isField || isIcon(child)
   )
 
   const styledChildren = children.map((child, i) => {
-    if (child.type.isIcon) {
+    if (isIcon(child)) {
       return React.cloneElement(child, {
         style: {
           ...child.props.style,
           flex: 'none',
           alignSelf: 'center',
-          pointerEvents: 'none',
+          pointerEvents: child.type.isIcon ? 'none' : 'auto',
           marginLeft: i === 0 ? 8 : -32,
           marginRight: i === 0 ? -32 : 8
         }

--- a/packages/core/storybook/IconField.js
+++ b/packages/core/storybook/IconField.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { IconField, Input, Select, Icon } from '../src'
+import { IconField, Input, Select, Icon, IconButton } from '../src'
+import { action } from '@storybook/addon-actions'
 
 storiesOf('IconField', module)
   .add('Icon and Input', () => (
@@ -15,11 +16,36 @@ storiesOf('IconField', module)
       <Icon name="Calendar" color="blue" />
     </IconField>
   ))
+  .add('Input and Icon Button', () => (
+    <IconField>
+      <Input placeholder="Choose Date" />
+      <IconButton
+        name="close"
+        size={24}
+        color="gray"
+        title="Clear text"
+        onClick={action('Icon button clicked')}
+      />
+    </IconField>
+  ))
   .add('Icon, Input, and Icon', () => (
     <IconField>
       <Icon name="Calendar" color="blue" />
       <Input placeholder="Choose Date" />
       <Icon name="Check" color="green" />
+    </IconField>
+  ))
+  .add('Icon, Input and Icon Button', () => (
+    <IconField>
+      <Icon name="Calendar" color="blue" />
+      <Input placeholder="Choose Date" />
+      <IconButton
+        name="Close"
+        size={24}
+        color="gray"
+        title="Clear text"
+        onClick={action('Icon button clicked')}
+      />
     </IconField>
   ))
   .add('Icon and Select', () => (

--- a/packages/core/test/IconField.js
+++ b/packages/core/test/IconField.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import TestRenderer from 'react-test-renderer'
-import { IconField, Icon, Input } from '../src'
+import { IconField, Icon, IconButton, Input } from '../src'
 
 describe('IconField', () => {
   test('renders', () => {
@@ -8,6 +8,27 @@ describe('IconField', () => {
       <IconField>
         <Icon name="Calendar" />
         <Input id="test" placeholder="IconField" />
+      </IconField>
+    ).toJSON()
+    expect(json).toMatchSnapshot()
+  })
+
+  test('renders icon button', () => {
+    const json = TestRenderer.create(
+      <IconField>
+        <Input id="test" placeholder="IconField" />
+        <IconButton name="close" />
+      </IconField>
+    ).toJSON()
+    expect(json).toMatchSnapshot()
+  })
+
+  test('renders icon, input and icon button together', () => {
+    const json = TestRenderer.create(
+      <IconField>
+        <Icon name="Calendar" />
+        <Input id="test" placeholder="IconField" />
+        <IconButton name="close" />
       </IconField>
     ).toJSON()
     expect(json).toMatchSnapshot()
@@ -58,5 +79,18 @@ describe('IconField', () => {
     const [icon, input] = json.children
     expect(input.props.style.paddingLeft).toBe(40)
     expect(input.props.style.paddingRight).toBe(undefined)
+  })
+
+  test('adds styles to the icon button on the right', () => {
+    const json = TestRenderer.create(
+      <IconField>
+        <Input id="test" />
+        <IconButton name="close" />
+      </IconField>
+    ).toJSON()
+    const [, iconButton] = json.children
+    expect(iconButton.props.style.pointerEvents).toBe('auto')
+    expect(iconButton.props.style.marginLeft).toBe(-32)
+    expect(iconButton.props.style.marginRight).toBe(8)
   })
 })

--- a/packages/core/test/__snapshots__/IconField.js.snap
+++ b/packages/core/test/__snapshots__/IconField.js.snap
@@ -102,3 +102,334 @@ exports[`IconField renders 1`] = `
   />
 </div>
 `;
+
+exports[`IconField renders icon button 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c4 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c3 {
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.5;
+  cursor: pointer;
+  border-radius: 2px;
+  background-color: #007aff;
+  color: #fff;
+  border-width: 0;
+  border-style: solid;
+  font-size: 14px;
+  padding: 9.5px 18px;
+}
+
+.c3:disabled {
+  opacity: 0.25;
+}
+
+.c3:hover {
+  background-color: #049;
+}
+
+.c2 {
+  padding: 0;
+  background-color: transparent;
+  color: inherit;
+}
+
+.c2:hover {
+  background-color: transparent;
+}
+
+.c2 > div {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: block;
+  width: 100%;
+  font-family: inherit;
+  font-size: 14px;
+  color: inherit;
+  background-color: transparent;
+  border-radius: 2px;
+  border-width: 0px;
+  border-style: solid;
+  border-color: #c0cad5;
+  padding-top: 14px;
+  padding-bottom: 14px;
+  padding-left: 12px;
+  padding-right: 12px;
+  margin: 0;
+  border-color: #c0cad5;
+  box-shadow: 0 0 0 1px #c0cad5;
+}
+
+.c1::-webkit-input-placeholder {
+  color: #4f6f8f;
+}
+
+.c1::-moz-placeholder {
+  color: #4f6f8f;
+}
+
+.c1:-ms-input-placeholder {
+  color: #4f6f8f;
+}
+
+.c1::placeholder {
+  color: #4f6f8f;
+}
+
+.c1::-ms-clear {
+  display: none;
+}
+
+.c1:focus {
+  outline: 0;
+  border-color: #007aff;
+  box-shadow: 0 0 0 2px #007aff;
+}
+
+<div
+  className="c0"
+>
+  <input
+    className="c1"
+    id="test"
+    placeholder="IconField"
+    style={
+      Object {
+        "paddingLeft": undefined,
+        "paddingRight": 40,
+      }
+    }
+  />
+  <button
+    className="c2 c3"
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": "none",
+        "marginLeft": -32,
+        "marginRight": 8,
+        "pointerEvents": "auto",
+      }
+    }
+  >
+    <div>
+      <svg
+        aria-hidden="true"
+        className="c4"
+        fill="currentcolor"
+        focusable="false"
+        height={24}
+        tabIndex="-1"
+        viewBox="0 0 24 24"
+        width={24}
+      >
+        <path
+          d="M19 6.4L17.6 5 12 10.6 6.4 5 5 6.4l5.6 5.6L5 17.6 6.4 19l5.6-5.6 5.6 5.6 1.4-1.4-5.6-5.6L19 6.4z"
+        />
+      </svg>
+    </div>
+  </button>
+</div>
+`;
+
+exports[`IconField renders icon, input and icon button together 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c4 {
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.5;
+  cursor: pointer;
+  border-radius: 2px;
+  background-color: #007aff;
+  color: #fff;
+  border-width: 0;
+  border-style: solid;
+  font-size: 14px;
+  padding: 9.5px 18px;
+}
+
+.c4:disabled {
+  opacity: 0.25;
+}
+
+.c4:hover {
+  background-color: #049;
+}
+
+.c3 {
+  padding: 0;
+  background-color: transparent;
+  color: inherit;
+}
+
+.c3:hover {
+  background-color: transparent;
+}
+
+.c3 > div {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: block;
+  width: 100%;
+  font-family: inherit;
+  font-size: 14px;
+  color: inherit;
+  background-color: transparent;
+  border-radius: 2px;
+  border-width: 0px;
+  border-style: solid;
+  border-color: #c0cad5;
+  padding-top: 14px;
+  padding-bottom: 14px;
+  padding-left: 12px;
+  padding-right: 12px;
+  margin: 0;
+  border-color: #c0cad5;
+  box-shadow: 0 0 0 1px #c0cad5;
+}
+
+.c2::-webkit-input-placeholder {
+  color: #4f6f8f;
+}
+
+.c2::-moz-placeholder {
+  color: #4f6f8f;
+}
+
+.c2:-ms-input-placeholder {
+  color: #4f6f8f;
+}
+
+.c2::placeholder {
+  color: #4f6f8f;
+}
+
+.c2::-ms-clear {
+  display: none;
+}
+
+.c2:focus {
+  outline: 0;
+  border-color: #007aff;
+  box-shadow: 0 0 0 2px #007aff;
+}
+
+<div
+  className="c0"
+>
+  <svg
+    aria-hidden="true"
+    className="c1"
+    fill="currentcolor"
+    focusable="false"
+    height={24}
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": "none",
+        "marginLeft": 8,
+        "marginRight": -32,
+        "pointerEvents": "none",
+      }
+    }
+    tabIndex="-1"
+    viewBox="0 0 24 24"
+    width={24}
+  >
+    <path
+      d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"
+    />
+  </svg>
+  <input
+    className="c2"
+    id="test"
+    placeholder="IconField"
+    style={
+      Object {
+        "paddingLeft": 40,
+        "paddingRight": 40,
+      }
+    }
+  />
+  <button
+    className="c3 c4"
+    style={
+      Object {
+        "alignSelf": "center",
+        "flex": "none",
+        "marginLeft": -32,
+        "marginRight": 8,
+        "pointerEvents": "auto",
+      }
+    }
+  >
+    <div>
+      <svg
+        aria-hidden="true"
+        className="c1"
+        fill="currentcolor"
+        focusable="false"
+        height={24}
+        tabIndex="-1"
+        viewBox="0 0 24 24"
+        width={24}
+      >
+        <path
+          d="M19 6.4L17.6 5 12 10.6 6.4 5 5 6.4l5.6 5.6L5 17.6 6.4 19l5.6-5.6 5.6 5.6 1.4-1.4-5.6-5.6L19 6.4z"
+        />
+      </svg>
+    </div>
+  </button>
+</div>
+`;


### PR DESCRIPTION
Currently, only an Icon is allowed inside a FormField. With these changes, we can also enable the use of an IconButton inside the FormField. 
The IconButton currently gets an outline when it is in focus in the FormField. If the changes from the other PR [https://github.com/pricelinelabs/design-system/pull/540](url) are merged, we will have an option to remove the outline form the IconButton in my understanding.