### PR TITLE
feat: add additional props to pcln modal for custom animations

### DIFF
--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -15,7 +15,7 @@ import Modal from 'pcln-modal'
 ```jsx
 import { Modal } from 'pcln-modal'
 
-;<Modal
+<Modal
   isOpen={true} //boolean for control this status of modal
   onClose={someFunc} //func function for handle close the modal while click on the overlay
   bg="white" //modal background color

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -70,12 +70,12 @@ For its animations, this Modal currently uses `react-transition-group`. This mea
 We can then use these states to write custom animations, like so:
 
 ```javascript
-const MY_ANIMATION = transitionstate => `
+const MY_ANIMATION = transitionState => `
   transform: scale(0.5);
   transition: transform .5s cubic-bezier(0.50, 0.00, 0.25, 1.00);
-  ${transitionstate === 'entering' ? `transform: scale(0.5);` : ''}
-  ${transitionstate === 'entered' ? `transform: scale(1);` : ''}
-  ${transitionstate === 'exiting' ? `transform: scale(0.5);` : ''}
-  ${transitionstate === 'exited' ? `transform: scale(0.5);` : ''}
+  ${transitionState === 'entering' ? `transform: scale(0.5);` : ''}
+  ${transitionState === 'entered' ? `transform: scale(1);` : ''}
+  ${transitionState === 'exiting' ? `transform: scale(0.5);` : ''}
+  ${transitionState === 'exited' ? `transform: scale(0.5);` : ''}
 `
 ```

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -15,7 +15,7 @@ import Modal from 'pcln-modal'
 ```jsx
 import { Modal } from 'pcln-modal'
 
-<Modal
+;<Modal
   isOpen={true} //boolean for control this status of modal
   onClose={someFunc} //func function for handle close the modal while click on the overlay
   bg="white" //modal background color
@@ -26,6 +26,9 @@ import { Modal } from 'pcln-modal'
   disableCloseButton={true} //there will be a floating close button, when enabledOverflow = true, it's there by default
   enableOverflow={false} //when enabled, the modal will extend over the screen based on content, otherwise it will follow height
   height={['100px', '200px']} //responsive height, when enableOverflow={true}, it's not in use
+  verticalAlignment="middle" // Aligns dialog body vertically - options = ['middle', 'top', 'bottom']
+  overlayAnimation={null} // Accepts a function which overwrites default animation
+  dialogAnimation={null} // Accepts a function which overwrites default animation
 >
   <SomeChildComponent />
 </Modal>
@@ -58,4 +61,21 @@ class SomeWrapper extends React.component {
     })
   }
 }
+```
+
+## Overwriting Animations
+
+For its animations, this Modal currently uses `react-transition-group`. This means that the following hooks are exposed during the animation life cycle: [ `entering`, `entered`, `exiting`, `exited`]
+
+We can then use these states to write custom animations, like so:
+
+```javascript
+const MY_ANIMATION = transitionstate => `
+  transform: scale(0.5);
+  transition: transform .5s cubic-bezier(0.50, 0.00, 0.25, 1.00);
+  ${transitionstate === 'entering' ? `transform: scale(0.5);` : ''}
+  ${transitionstate === 'entered' ? `transform: scale(1);` : ''}
+  ${transitionstate === 'exiting' ? `transform: scale(0.5);` : ''}
+  ${transitionstate === 'exited' ? `transform: scale(0.5);` : ''}
+`
 ```

--- a/packages/modal/src/Modal.js
+++ b/packages/modal/src/Modal.js
@@ -6,34 +6,31 @@ import { color, width, height } from 'styled-system'
 import { DialogOverlay, DialogContent } from '@reach/dialog'
 import { Box, CloseButton, Flex } from 'pcln-design-system'
 
-const OVERLAY_ANIMATION = transitionstate => `
+const OVERLAY_ANIMATION = transitionState => `
   opacity: 0;
   transition: opacity .5s cubic-bezier(0.50, 0.00, 0.25, 1.00);
-  ${transitionstate === 'entering' ? `opacity: 0;` : ''}
-  ${transitionstate === 'entered' ? `opacity: 1;` : ''}
-  ${transitionstate === 'exiting' ? `opacity: 0;` : ''}
-  ${transitionstate === 'exited' ? `opacity: 0;` : ''}
+  ${transitionState === 'entering' ? `opacity: 0;` : ''}
+  ${transitionState === 'entered' ? `opacity: 1;` : ''}
+  ${transitionState === 'exiting' ? `opacity: 0;` : ''}
+  ${transitionState === 'exited' ? `opacity: 0;` : ''}
 `
 
-const DIALOG_ANIMATION = transitionstate => `
+const DIALOG_ANIMATION = transitionState => `
   transform: scale(0.5);
   transition: transform .5s cubic-bezier(0.50, 0.00, 0.25, 1.00);
-  ${transitionstate === 'entering' ? `transform: scale(0.5);` : ''}
-  ${transitionstate === 'entered' ? `transform: scale(1);` : ''}
-  ${transitionstate === 'exiting' ? `transform: scale(0.5);` : ''}
-  ${transitionstate === 'exited' ? `transform: scale(0.5);` : ''}
+  ${transitionState === 'entering' ? `transform: scale(0.5);` : ''}
+  ${transitionState === 'entered' ? `transform: scale(1);` : ''}
+  ${transitionState === 'exiting' ? `transform: scale(0.5);` : ''}
+  ${transitionState === 'exited' ? `transform: scale(0.5);` : ''}
 `
 
 const getAnimation = ({
   transitionstate,
   defaultAnimation,
   customAnimation = null
-}) => {
-  if (customAnimation && typeof customAnimation === 'function') {
-    return customAnimation(transitionstate)
-  }
-  return defaultAnimation(transitionstate)
-}
+}) => typeof customAnimation === 'function'
+  ? customAnimation(transitionstate)
+  : defaultAnimation(transitionstate)
 
 const Overlay = styled(DialogOverlay)`
   background-color: rgba(0, 0, 0, 0.7);

--- a/packages/modal/storybook/Modal.js
+++ b/packages/modal/storybook/Modal.js
@@ -7,7 +7,7 @@ import styled from 'styled-components'
 const StyledModal = styled(Modal)`
   height: ${props => props.height};
 `
-const CUSTOM_ANIMATION = transitionstate => `
+const CUSTOM_ANIMATION = transitionState => `
   transform: translateY(-122%);
   transition: transform 0.3s linear;
   ${transitionstate === 'entered' ? `transform: translateY(0%);` : ''}

--- a/packages/modal/storybook/Modal.js
+++ b/packages/modal/storybook/Modal.js
@@ -10,7 +10,7 @@ const StyledModal = styled(Modal)`
 const CUSTOM_ANIMATION = transitionState => `
   transform: translateY(-122%);
   transition: transform 0.3s linear;
-  ${transitionstate === 'entered' ? `transform: translateY(0%);` : ''}
+  ${transitionState === 'entered' ? `transform: translateY(0%);` : ''}
 `
 
 class ModalStory extends React.Component {

--- a/packages/modal/storybook/Modal.js
+++ b/packages/modal/storybook/Modal.js
@@ -7,6 +7,11 @@ import styled from 'styled-components'
 const StyledModal = styled(Modal)`
   height: ${props => props.height};
 `
+const CUSTOM_ANIMATION = transitionstate => `
+  transform: translateY(-122%);
+  transition: transform 0.3s linear;
+  ${transitionstate === 'entered' ? `transform: translateY(0%);` : ''}
+`
 
 class ModalStory extends React.Component {
   constructor(props) {
@@ -99,5 +104,14 @@ storiesOf('Modal', module)
       width={['100px', '200px', '500px']}
       imgMode
       disableCloseButton
+    />
+  ))
+
+  .add('With custom animation', () => (
+    <ModalStory
+      header={<SmallModalHeader />}
+      width={['100px', '200px', '500px']}
+      dialogAnimation={CUSTOM_ANIMATION}
+      verticalAlignment="top"
     />
   ))

--- a/packages/modal/test/Modal.js
+++ b/packages/modal/test/Modal.js
@@ -74,4 +74,34 @@ describe('Modal', () => {
     )
     expect(getByText('header')).toBeTruthy()
   })
+  test('renders with top alignment', () => {
+    const { getByText, getByTestId, container } = rerender(
+      <ThemeProvider>
+        <Modal isOpen verticalAlignment="top">
+          <div data-content>Content</div>
+        </Modal>
+      </ThemeProvider>
+    )
+    expect(getByText('Content')).toBeTruthy()
+    expect(getByTestId('pcln-modal-close')).toBeTruthy()
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  test('renders with custom animation', () => {
+    const { getByText, getByTestId, container } = rerender(
+      <ThemeProvider>
+        <Modal
+          isOpen
+          overlayAnimation={transitionstate =>
+            `${transitionstate === 'entering' ? `transform: scale(0.5);` : ''}`
+          }
+        >
+          <div data-content>Content</div>
+        </Modal>
+      </ThemeProvider>
+    )
+    expect(getByText('Content')).toBeTruthy()
+    expect(getByTestId('pcln-modal-close')).toBeTruthy()
+    expect(container.firstChild).toMatchSnapshot()
+  })
 })

--- a/packages/modal/test/__snapshots__/Modal.js.snap
+++ b/packages/modal/test/__snapshots__/Modal.js.snap
@@ -37,3 +37,41 @@ exports[`Modal renders when open 1`] = `
   />
 </div>
 `;
+
+exports[`Modal renders with custom animation 1`] = `
+.c0 {
+  font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.4;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c0"
+  />
+</div>
+`;
+
+exports[`Modal renders with top alignment 1`] = `
+.c0 {
+  font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
+  line-height: 1.4;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c0"
+  />
+</div>
+`;


### PR DESCRIPTION
With all the a11y work, there will be some instances of the modal that require different animations and alignment on the page in order to match existing design. This PR adds new props to allow consumers to overwrite animations for both the overlay and the dialog, as well as change the vertical alignment of the dialog on the page.