### PR TITLE
set explicit rules for FormField label and icon

### DIFF
--- a/packages/core/src/FormField.js
+++ b/packages/core/src/FormField.js
@@ -47,7 +47,9 @@ const FormField = props => {
         height: 20,
         transitionProperty: 'opacity',
         transitionDuration: '.1s',
-        opacity: showLabel ? 1 : 0
+        opacity: showLabel ? 1 : 0,
+        pointerEvents: 'none',
+        position: 'relative'
       }
     })
 

--- a/packages/core/src/IconField.js
+++ b/packages/core/src/IconField.js
@@ -17,7 +17,8 @@ const IconField = props => {
           alignSelf: 'center',
           pointerEvents: child.type.isIcon ? 'none' : 'auto',
           marginLeft: i === 0 ? 8 : -32,
-          marginRight: i === 0 ? -32 : 8
+          marginRight: i === 0 ? -32 : 8,
+          position: 'relative'
         }
       })
     }

--- a/packages/core/storybook/FormField.js
+++ b/packages/core/storybook/FormField.js
@@ -17,7 +17,12 @@ storiesOf('FormField', module)
     <FormField>
       <Label htmlFor="demo">Email Address</Label>
       <Icon name="Email" color="blue" />
-      <Input id="demo" name="demo" defaultValue="hello@example.com" />
+      <Input
+        type="email"
+        id="email"
+        name="email"
+        defaultValue="hello@example.com"
+      />
     </FormField>
   ))
   .add('dynamic label', () => (

--- a/packages/core/test/__snapshots__/FormField.js.snap
+++ b/packages/core/test/__snapshots__/FormField.js.snap
@@ -85,6 +85,8 @@ exports[`FormField renders 1`] = `
       Object {
         "height": 20,
         "opacity": 1,
+        "pointerEvents": "none",
+        "position": "relative",
         "transitionDuration": ".1s",
         "transitionProperty": "opacity",
       }
@@ -204,6 +206,8 @@ exports[`FormField renders with Icon 1`] = `
       Object {
         "height": 20,
         "opacity": 1,
+        "pointerEvents": "none",
+        "position": "relative",
         "transitionDuration": ".1s",
         "transitionProperty": "opacity",
       }
@@ -227,6 +231,7 @@ exports[`FormField renders with Icon 1`] = `
           "marginLeft": 8,
           "marginRight": -32,
           "pointerEvents": "none",
+          "position": "relative",
         }
       }
       tabIndex="-1"
@@ -347,6 +352,8 @@ exports[`FormField renders with Label autoHide prop 1`] = `
       Object {
         "height": 20,
         "opacity": 0,
+        "pointerEvents": "none",
+        "position": "relative",
         "transitionDuration": ".1s",
         "transitionProperty": "opacity",
       }
@@ -370,6 +377,7 @@ exports[`FormField renders with Label autoHide prop 1`] = `
           "marginLeft": 8,
           "marginRight": -32,
           "pointerEvents": "none",
+          "position": "relative",
         }
       }
       tabIndex="-1"
@@ -582,6 +590,7 @@ exports[`FormField renders with Select and Icon 1`] = `
           "marginLeft": 8,
           "marginRight": -32,
           "pointerEvents": "none",
+          "position": "relative",
         }
       }
       tabIndex="-1"

--- a/packages/core/test/__snapshots__/IconField.js.snap
+++ b/packages/core/test/__snapshots__/IconField.js.snap
@@ -79,6 +79,7 @@ exports[`IconField renders 1`] = `
         "marginLeft": 8,
         "marginRight": -32,
         "pointerEvents": "none",
+        "position": "relative",
       }
     }
     tabIndex="-1"
@@ -234,6 +235,7 @@ exports[`IconField renders icon button 1`] = `
         "marginLeft": -32,
         "marginRight": 8,
         "pointerEvents": "auto",
+        "position": "relative",
       }
     }
   >
@@ -381,6 +383,7 @@ exports[`IconField renders icon, input and icon button together 1`] = `
         "marginLeft": 8,
         "marginRight": -32,
         "pointerEvents": "none",
+        "position": "relative",
       }
     }
     tabIndex="-1"
@@ -411,6 +414,7 @@ exports[`IconField renders icon, input and icon button together 1`] = `
         "marginLeft": -32,
         "marginRight": 8,
         "pointerEvents": "auto",
+        "position": "relative",
       }
     }
   >


### PR DESCRIPTION
Addresses #530 
* position relative for both label and icon to address autocomplete bug
* pointerEvents none to allow focus on input when label clicked
* added type to FormField story input for testing purposes

Before:
<img width="1403" alt="Screen Shot 2019-08-19 at 10 03 57 AM" src="https://user-images.githubusercontent.com/5533800/63271722-bb85b480-c268-11e9-92da-6e2ed2b23109.png">

After:
<img width="1405" alt="Screen Shot 2019-08-19 at 10 03 25 AM" src="https://user-images.githubusercontent.com/5533800/63271739-c04a6880-c268-11e9-9d7b-3cefd21f3f36.png">
