### PR TITLE
Remove Warnings and Update Readme for Theming

### DIFF
--- a/packages/core/test/IconButton.js
+++ b/packages/core/test/IconButton.js
@@ -8,13 +8,15 @@ afterEach(cleanup)
 describe('IconButton', () => {
   test('executes onClick prop on click', () => {
     const handleClick = jest.fn()
-    const { container } = renderWithTheme(<IconButton onClick={handleClick} />)
+    const { container } = renderWithTheme(
+      <IconButton name="key" onClick={handleClick} />
+    )
     fireEvent.click(container.firstChild)
     expect(handleClick).toBeCalled()
   })
 
   test('renders without props', () => {
-    const json = rendererCreateWithTheme(<IconButton />).toJSON()
+    const json = rendererCreateWithTheme(<IconButton name="key" />).toJSON()
     expect(json).toMatchSnapshot()
   })
 })

--- a/packages/core/test/__snapshots__/Banner.js.snap
+++ b/packages/core/test/__snapshots__/Banner.js.snap
@@ -125,12 +125,12 @@ exports[`Banner renders content from children props 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -218,12 +218,12 @@ exports[`Banner renders with blue bg 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -308,12 +308,12 @@ exports[`Banner renders with custom iconName and size 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -398,12 +398,12 @@ exports[`Banner renders with green bg 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -488,12 +488,12 @@ exports[`Banner renders with lightBlue bg 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -578,12 +578,12 @@ exports[`Banner renders with lightGreen bg 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -668,12 +668,12 @@ exports[`Banner renders with lightRed bg 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -758,12 +758,12 @@ exports[`Banner renders with no props other than theme 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -848,12 +848,12 @@ exports[`Banner renders with orange bg 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -938,12 +938,12 @@ exports[`Banner renders with red bg 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -1028,12 +1028,12 @@ exports[`Banner renders with text node 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -1126,12 +1126,12 @@ exports[`Banner renders with text string 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >

--- a/packages/core/test/__snapshots__/Checkbox.js.snap
+++ b/packages/core/test/__snapshots__/Checkbox.js.snap
@@ -92,13 +92,13 @@ exports[`Checkbox renders disabled with defaultChecked 1`] = `
     type="checkbox"
   />
   <svg
-    aria-hidden="true"
+    aria-hidden={true}
     className="c3"
     data-name="checked"
     fill="currentcolor"
-    focusable="false"
+    focusable={false}
     height={24}
-    tabIndex="-1"
+    tabIndex={-1}
     viewBox="0 0 24 24"
     width={24}
   >
@@ -107,13 +107,13 @@ exports[`Checkbox renders disabled with defaultChecked 1`] = `
     />
   </svg>
   <svg
-    aria-hidden="true"
+    aria-hidden={true}
     className="c3"
     data-name="empty"
     fill="currentcolor"
-    focusable="false"
+    focusable={false}
     height={24}
-    tabIndex="-1"
+    tabIndex={-1}
     viewBox="0 0 24 24"
     width={24}
   >

--- a/packages/core/test/__snapshots__/CloseButton.js.snap
+++ b/packages/core/test/__snapshots__/CloseButton.js.snap
@@ -56,12 +56,12 @@ exports[`CloseButton renders without props 1`] = `
 >
   <div>
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >

--- a/packages/core/test/__snapshots__/FormField.js.snap
+++ b/packages/core/test/__snapshots__/FormField.js.snap
@@ -217,10 +217,10 @@ exports[`FormField renders with Icon 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
       style={
         Object {
@@ -232,7 +232,7 @@ exports[`FormField renders with Icon 1`] = `
           "position": "relative",
         }
       }
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -362,10 +362,10 @@ exports[`FormField renders with Label autoHide prop 1`] = `
     className="c1 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c2"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
       style={
         Object {
@@ -377,7 +377,7 @@ exports[`FormField renders with Label autoHide prop 1`] = `
           "position": "relative",
         }
       }
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -490,13 +490,13 @@ exports[`FormField renders with Select  1`] = `
         }
       />
       <svg
-        aria-hidden="true"
+        aria-hidden={true}
         className="c4 c5"
         color="gray"
         fill="currentcolor"
-        focusable="false"
+        focusable={false}
         height={24}
-        tabIndex="-1"
+        tabIndex={-1}
         viewBox="0 0 24 24"
         width={24}
       >
@@ -582,10 +582,10 @@ exports[`FormField renders with Select and Icon 1`] = `
     className="c0 "
   >
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c1"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={24}
       style={
         Object {
@@ -597,7 +597,7 @@ exports[`FormField renders with Select and Icon 1`] = `
           "position": "relative",
         }
       }
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={24}
     >
@@ -625,13 +625,13 @@ exports[`FormField renders with Select and Icon 1`] = `
         }
       />
       <svg
-        aria-hidden="true"
+        aria-hidden={true}
         className="c5 c6"
         color="gray"
         fill="currentcolor"
-        focusable="false"
+        focusable={false}
         height={24}
-        tabIndex="-1"
+        tabIndex={-1}
         viewBox="0 0 24 24"
         width={24}
       >

--- a/packages/core/test/__snapshots__/IconButton.js.snap
+++ b/packages/core/test/__snapshots__/IconButton.js.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IconButton renders without props 1`] = `
+.c2 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
 .c1 {
   -webkit-font-smoothing: antialiased;
   display: inline-block;
@@ -47,6 +53,21 @@ exports[`IconButton renders without props 1`] = `
   className="c0 c1"
   color="primary"
 >
-  <div />
+  <div>
+    <svg
+      aria-hidden={true}
+      className="c2"
+      fill="currentcolor"
+      focusable={false}
+      height={24}
+      tabIndex={-1}
+      viewBox="0 0 24 24"
+      width={24}
+    >
+      <path
+        d="M12.6 10.1C11.8 8 9.8 6.5 7.5 6.5 4.4 6.5 2 8.9 2 12s2.4 5.5 5.5 5.5c2.4 0 4.4-1.5 5.1-3.6h4v3.6h3.6v-3.7H22v-3.7h-9.4zm-5.1 3.7c-1 0-1.8-.8-1.8-1.8s.8-1.8 1.8-1.8 1.8.8 1.8 1.8-.8 1.8-1.8 1.8z"
+      />
+    </svg>
+  </div>
 </button>
 `;

--- a/packages/core/test/__snapshots__/IconField.js.snap
+++ b/packages/core/test/__snapshots__/IconField.js.snap
@@ -66,10 +66,10 @@ exports[`IconField renders 1`] = `
   className="c0 "
 >
   <svg
-    aria-hidden="true"
+    aria-hidden={true}
     className="c1"
     fill="currentcolor"
-    focusable="false"
+    focusable={false}
     height={24}
     style={
       Object {
@@ -81,7 +81,7 @@ exports[`IconField renders 1`] = `
         "position": "relative",
       }
     }
-    tabIndex="-1"
+    tabIndex={-1}
     viewBox="0 0 24 24"
     width={24}
   >
@@ -237,12 +237,12 @@ exports[`IconField renders icon button 1`] = `
   >
     <div>
       <svg
-        aria-hidden="true"
+        aria-hidden={true}
         className="c4"
         fill="currentcolor"
-        focusable="false"
+        focusable={false}
         height={24}
-        tabIndex="-1"
+        tabIndex={-1}
         viewBox="0 0 24 24"
         width={24}
       >
@@ -363,10 +363,10 @@ exports[`IconField renders icon, input and icon button together 1`] = `
   className="c0 "
 >
   <svg
-    aria-hidden="true"
+    aria-hidden={true}
     className="c1"
     fill="currentcolor"
-    focusable="false"
+    focusable={false}
     height={24}
     style={
       Object {
@@ -378,7 +378,7 @@ exports[`IconField renders icon, input and icon button together 1`] = `
         "position": "relative",
       }
     }
-    tabIndex="-1"
+    tabIndex={-1}
     viewBox="0 0 24 24"
     width={24}
   >
@@ -413,12 +413,12 @@ exports[`IconField renders icon, input and icon button together 1`] = `
   >
     <div>
       <svg
-        aria-hidden="true"
+        aria-hidden={true}
         className="c1"
         fill="currentcolor"
-        focusable="false"
+        focusable={false}
         height={24}
-        tabIndex="-1"
+        tabIndex={-1}
         viewBox="0 0 24 24"
         width={24}
       >

--- a/packages/core/test/__snapshots__/Radio.js.snap
+++ b/packages/core/test/__snapshots__/Radio.js.snap
@@ -74,12 +74,12 @@ exports[`Radio Disabled, rendering 1`] = `
       type="radio"
     />
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c3 c4"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={28}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={28}
     >
@@ -167,12 +167,12 @@ exports[`Radio Not Selected, rendering 1`] = `
       type="radio"
     />
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c3 c4"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={28}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={28}
     >
@@ -262,12 +262,12 @@ exports[`Radio Selected, rendering 1`] = `
       type="radio"
     />
     <svg
-      aria-hidden="true"
+      aria-hidden={true}
       className="c3 c4"
       fill="currentcolor"
-      focusable="false"
+      focusable={false}
       height={28}
-      tabIndex="-1"
+      tabIndex={-1}
       viewBox="0 0 24 24"
       width={28}
     >

--- a/packages/core/test/__snapshots__/Select.js.snap
+++ b/packages/core/test/__snapshots__/Select.js.snap
@@ -65,13 +65,13 @@ exports[`Select renders 1`] = `
     fontSize={1}
   />
   <svg
-    aria-hidden="true"
+    aria-hidden={true}
     className="c3 c4"
     color="gray"
     fill="currentcolor"
-    focusable="false"
+    focusable={false}
     height={24}
-    tabIndex="-1"
+    tabIndex={-1}
     viewBox="0 0 24 24"
     width={24}
   >

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,4 +1,3 @@
-
 # pcln-icons
 
 Priceline React icons based on Material Design Icons
@@ -13,11 +12,7 @@ npm i pcln-icons
 import React from 'react'
 import FlightsIcon from 'pcln-icons/lib/Flights'
 
-export default props =>
-  <FlightsIcon
-    mr={2}
-    color='blue'
-  />
+export default props => <FlightsIcon mr={2} />
 ```
 
 For a complete list of all icons, see: [the iconography docs](https://pricelinelabs.github.io/design-system/iconography)
@@ -30,11 +25,7 @@ For backwards compatibility, the `Icon` component can be used in the same way as
 import React from 'react'
 import Icon from 'pcln-icons'
 
-export default props =>
-  <Icon
-    name='Flights'
-    color='blue'
-  />
+export default props => <Icon name="Flights" />
 ```
 
 ## Development
@@ -62,4 +53,3 @@ components/ React components for icons
 test/       Unit tests
 lib/        Icon components compiled to commonjs format
 ```
-

--- a/packages/icons/src/Icon.js
+++ b/packages/icons/src/Icon.js
@@ -1,55 +1,39 @@
 import React from 'react'
 import upperFirst from 'lodash.upperfirst'
 import PropTypes from 'prop-types'
-
 import * as icons from './index'
 
 const Icon = ({ name, title, desc, titleId, descId, ...props }) => {
   const Component = icons[name] || icons[upperFirst(name)]
-  if (!Component) return false
 
-  /**
-   *  To support older browsers, make sure 'titleId' is passed along with 'title' props and
-   * 'descId' with 'desc' props
-   * Also, <desc> element should be followed by a <title> tag for <svg> elements
-   * */
-  if (!!title) {
-    let ariaLabelledBy = ''
-    props['aria-hidden'] = 'false'
-
-    if (!!titleId) {
-      ariaLabelledBy = titleId
-    }
-
-    if (!!desc && !!descId) {
-      ariaLabelledBy = `${ariaLabelledBy} ${descId}`
-    }
-
-    if (!!ariaLabelledBy) {
-      props['aria-labelledby'] = ariaLabelledBy
-    }
-  }
+  let ariaLabelledBy = titleId ? titleId : ''
+  ariaLabelledBy += desc && descId ? ` ${descId}` : ''
+  ariaLabelledBy = ariaLabelledBy ? ariaLabelledBy : undefined
 
   return (
-    <Component
-      title={title}
-      desc={desc}
-      titleId={titleId}
-      descId={descId}
-      {...props}
-    />
+    Component && (
+      <Component
+        title={title}
+        desc={desc}
+        titleId={titleId}
+        descId={descId}
+        aria-hidden={!!ariaLabelledBy}
+        aria-labelledby={ariaLabelledBy}
+        {...props}
+      />
+    )
   )
 }
 
+Icon.isIcon = true
+Icon.displayName = 'Icon'
+
 Icon.defaultProps = {
   size: 24,
-  'aria-hidden': 'true',
-  focusable: 'false',
-  tabIndex: '-1'
+  tabIndex: -1,
+  focusable: false,
+  'aria-hidden': true
 }
-
-Icon.displayName = 'Icon'
-Icon.isIcon = true
 
 Icon.propTypes = {
   name: (props, key, componentName) => {
@@ -58,40 +42,11 @@ Icon.propTypes = {
       return new Error(
         `Unknown name prop \`${name}\` supplied to \`${componentName}\``
       )
-    } else if (!icons[name]) {
-      return new Error(
-        `Icon name prop should be uppercase.\n` +
-          `Use \`${upperFirst(name)}\` instead of ${name}.`
-      )
     }
   },
-  title: (props, propName, componentName) => {
-    if (typeof props[propName] !== 'string') {
-      return new Error(
-        `'title' prop supplied to '${componentName}' should be a string`
-      )
-    } else if (!!props[propName] && !props['titleId']) {
-      return new Error(
-        `'titleId' prop should be passed along with 'title' prop to '${componentName}'`
-      )
-    }
-  },
-  desc: (props, propName, componentName) => {
-    if (typeof props[propName] !== 'string') {
-      return new Error(
-        `'desc' prop supplied to '${componentName}' should be a string`
-      )
-    } else if (!!props[propName] && !props['title']) {
-      return new Error(
-        `'title' prop should be passed along with 'desc' prop to '${componentName}'`
-      )
-    } else if (!!props[propName] && !props['descId']) {
-      return new Error(
-        `'descId' prop should be passed along with 'desc' prop to '${componentName}'`
-      )
-    }
-  },
+  title: PropTypes.string,
   titleId: PropTypes.string,
+  desc: PropTypes.string,
   descId: PropTypes.string
 }
 

--- a/packages/icons/svgr.config.js
+++ b/packages/icons/svgr.config.js
@@ -24,9 +24,9 @@ ${componentName}.isIcon = true
 
 ${componentName}.defaultProps = {
   size: 24,
-  'aria-hidden': 'true',
-  'focusable': 'false',
-  tabIndex: '-1'
+  tabIndex: -1,
+  focusable: false,
+  'aria-hidden': true
 }
 
 export default ${componentName}`

--- a/packages/icons/test/__snapshots__/index.js.snap
+++ b/packages/icons/test/__snapshots__/index.js.snap
@@ -8,12 +8,12 @@ exports[`renders Ac 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -31,12 +31,12 @@ exports[`renders Accessible 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -54,12 +54,12 @@ exports[`renders Airplane 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -77,12 +77,12 @@ exports[`renders Arrival 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -100,12 +100,12 @@ exports[`renders ArrowDown 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -123,12 +123,12 @@ exports[`renders ArrowLeft 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -146,12 +146,12 @@ exports[`renders ArrowRight 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -169,12 +169,12 @@ exports[`renders ArrowUp 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -192,12 +192,12 @@ exports[`renders Attention 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -215,12 +215,12 @@ exports[`renders Automatic 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -238,12 +238,12 @@ exports[`renders Bag 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -261,12 +261,12 @@ exports[`renders Beach 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -284,12 +284,12 @@ exports[`renders Bed 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -307,12 +307,12 @@ exports[`renders BoxChecked 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -330,12 +330,12 @@ exports[`renders BoxEmpty 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -353,12 +353,12 @@ exports[`renders BoxMinus 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -376,12 +376,12 @@ exports[`renders BoxPlus 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -399,12 +399,12 @@ exports[`renders Breakfast 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -422,12 +422,12 @@ exports[`renders Build 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -445,12 +445,12 @@ exports[`renders Business 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -468,12 +468,12 @@ exports[`renders Cake 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -491,12 +491,12 @@ exports[`renders Calendar 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -514,12 +514,12 @@ exports[`renders CarCircle 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -537,12 +537,12 @@ exports[`renders CarDoor 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -560,12 +560,12 @@ exports[`renders Carriage 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -583,12 +583,12 @@ exports[`renders Cars 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -606,12 +606,12 @@ exports[`renders Casino 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -629,12 +629,12 @@ exports[`renders Chart 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -652,12 +652,12 @@ exports[`renders Chat 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -675,12 +675,12 @@ exports[`renders Check 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -698,12 +698,12 @@ exports[`renders ChevronDown 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -721,12 +721,12 @@ exports[`renders ChevronLeft 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -744,12 +744,12 @@ exports[`renders ChevronRight 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -767,12 +767,12 @@ exports[`renders ChevronUp 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -790,12 +790,12 @@ exports[`renders CityView 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -813,12 +813,12 @@ exports[`renders Clock 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -836,12 +836,12 @@ exports[`renders Close 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -859,12 +859,12 @@ exports[`renders Cloud 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -882,12 +882,12 @@ exports[`renders CollisionCoverage 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -905,12 +905,12 @@ exports[`renders Coupon 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -928,12 +928,12 @@ exports[`renders CreditCard 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -951,12 +951,12 @@ exports[`renders Cruises 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -974,12 +974,12 @@ exports[`renders Departure 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -997,12 +997,12 @@ exports[`renders Devices 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1020,12 +1020,12 @@ exports[`renders Directions 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1043,12 +1043,12 @@ exports[`renders Discount 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1066,12 +1066,12 @@ exports[`renders Document 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1089,12 +1089,12 @@ exports[`renders Dollar 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1112,12 +1112,12 @@ exports[`renders DollarCircle 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1135,12 +1135,12 @@ exports[`renders Dot 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1158,12 +1158,12 @@ exports[`renders DoubleOccupancy 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1181,12 +1181,12 @@ exports[`renders EarlyBird 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1204,12 +1204,12 @@ exports[`renders Edit 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1227,12 +1227,12 @@ exports[`renders Electric 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1250,12 +1250,12 @@ exports[`renders Email 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1273,12 +1273,12 @@ exports[`renders Emoticon 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1296,12 +1296,12 @@ exports[`renders Event 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1319,12 +1319,12 @@ exports[`renders EventAvailable 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1342,12 +1342,12 @@ exports[`renders EventBusy 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1365,12 +1365,12 @@ exports[`renders Facebook 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1388,12 +1388,12 @@ exports[`renders FavoriteHotel 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1411,12 +1411,12 @@ exports[`renders Filter 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1434,12 +1434,12 @@ exports[`renders Fitness 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1457,12 +1457,12 @@ exports[`renders Flame 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1480,12 +1480,12 @@ exports[`renders FlightCircle 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1503,12 +1503,12 @@ exports[`renders FlightCoverage 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1526,12 +1526,12 @@ exports[`renders Flights 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1549,12 +1549,12 @@ exports[`renders FreeCancellation 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1572,12 +1572,12 @@ exports[`renders Fridge 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1595,12 +1595,12 @@ exports[`renders Gallery 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1618,12 +1618,12 @@ exports[`renders Gas 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1641,12 +1641,12 @@ exports[`renders Globe 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1664,12 +1664,12 @@ exports[`renders Golf 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1687,12 +1687,12 @@ exports[`renders Gps 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1710,12 +1710,12 @@ exports[`renders Graph 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1733,12 +1733,12 @@ exports[`renders Grid 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1756,12 +1756,12 @@ exports[`renders GuestScore 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1779,12 +1779,12 @@ exports[`renders Guests 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1802,12 +1802,12 @@ exports[`renders Help 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1825,12 +1825,12 @@ exports[`renders History 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1848,12 +1848,12 @@ exports[`renders Home 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1871,12 +1871,12 @@ exports[`renders HotelCircle 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1894,12 +1894,12 @@ exports[`renders Hotels 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1917,12 +1917,12 @@ exports[`renders House 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1940,12 +1940,12 @@ exports[`renders Hybrid 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1963,12 +1963,12 @@ exports[`renders Inclusive 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -1986,12 +1986,12 @@ exports[`renders Information 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2009,12 +2009,12 @@ exports[`renders InformationOutline 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2032,12 +2032,12 @@ exports[`renders Instagram 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2055,12 +2055,12 @@ exports[`renders Key 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2078,12 +2078,12 @@ exports[`renders Kitchenette 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2101,12 +2101,12 @@ exports[`renders Laptop 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2124,12 +2124,12 @@ exports[`renders LateNight 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2147,12 +2147,12 @@ exports[`renders List 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2170,12 +2170,12 @@ exports[`renders LocalBar 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2193,12 +2193,12 @@ exports[`renders Lock 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2216,12 +2216,12 @@ exports[`renders Loyalty 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2239,12 +2239,12 @@ exports[`renders Luggage 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2262,12 +2262,12 @@ exports[`renders Manual 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2285,12 +2285,12 @@ exports[`renders Map 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2308,12 +2308,12 @@ exports[`renders Menu 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2331,12 +2331,12 @@ exports[`renders Microwave 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2354,12 +2354,12 @@ exports[`renders Mileage 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2377,12 +2377,12 @@ exports[`renders Minus 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2400,12 +2400,12 @@ exports[`renders MultiAirline 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2423,12 +2423,12 @@ exports[`renders MultiOccupancy 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2446,12 +2446,12 @@ exports[`renders Notification 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2469,12 +2469,12 @@ exports[`renders Overnight 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2492,12 +2492,12 @@ exports[`renders Parking 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2515,12 +2515,12 @@ exports[`renders Pets 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2538,12 +2538,12 @@ exports[`renders Phone 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2561,12 +2561,12 @@ exports[`renders Picture 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2584,12 +2584,12 @@ exports[`renders Pin 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2607,12 +2607,12 @@ exports[`renders Plus 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2630,12 +2630,12 @@ exports[`renders Pool 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2653,12 +2653,12 @@ exports[`renders Printer 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2676,12 +2676,12 @@ exports[`renders Quilt 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2699,12 +2699,12 @@ exports[`renders RadioChecked 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2722,12 +2722,12 @@ exports[`renders RadioEmpty 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2745,12 +2745,12 @@ exports[`renders RadioMinus 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2768,12 +2768,12 @@ exports[`renders RadioPlus 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2791,12 +2791,12 @@ exports[`renders Refresh 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2814,12 +2814,12 @@ exports[`renders Restaurant 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2837,12 +2837,12 @@ exports[`renders Ribbon 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2860,12 +2860,12 @@ exports[`renders RoomSize 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2883,12 +2883,12 @@ exports[`renders Rowing 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2906,12 +2906,12 @@ exports[`renders Search 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2929,12 +2929,12 @@ exports[`renders SearchRecent 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2952,12 +2952,12 @@ exports[`renders Seat 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2975,12 +2975,12 @@ exports[`renders SeatBusiness 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -2998,12 +2998,12 @@ exports[`renders SeatEconomy 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3021,12 +3021,12 @@ exports[`renders Security 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3044,12 +3044,12 @@ exports[`renders Shuttle 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3067,12 +3067,12 @@ exports[`renders SingleOccupancy 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3090,12 +3090,12 @@ exports[`renders Smoking 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3113,12 +3113,12 @@ exports[`renders Spa 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3136,12 +3136,12 @@ exports[`renders SplitTicket 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3159,12 +3159,12 @@ exports[`renders Star 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3182,12 +3182,12 @@ exports[`renders StarHalf 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3205,12 +3205,12 @@ exports[`renders SteeringWheel 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3228,12 +3228,12 @@ exports[`renders Success 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3251,12 +3251,12 @@ exports[`renders SuccessOutline 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3274,12 +3274,12 @@ exports[`renders Swap 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3297,12 +3297,12 @@ exports[`renders ThumbsDown 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3320,12 +3320,12 @@ exports[`renders ThumbsUp 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3343,12 +3343,12 @@ exports[`renders Timer 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3366,12 +3366,12 @@ exports[`renders TrendingUp 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3389,12 +3389,12 @@ exports[`renders Trophy 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3412,12 +3412,12 @@ exports[`renders Tune 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3435,12 +3435,12 @@ exports[`renders Twitter 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3458,12 +3458,12 @@ exports[`renders Unlock 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3481,12 +3481,12 @@ exports[`renders User 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3504,12 +3504,12 @@ exports[`renders Verified 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3527,12 +3527,12 @@ exports[`renders Warning 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3550,12 +3550,12 @@ exports[`renders WarningOutline 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3573,12 +3573,12 @@ exports[`renders Web 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3596,12 +3596,12 @@ exports[`renders Whirlpool 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3619,12 +3619,12 @@ exports[`renders Wifi 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3642,12 +3642,12 @@ exports[`renders Youtube 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >
@@ -3665,12 +3665,12 @@ exports[`renders ZoomOut 1`] = `
 }
 
 <svg
-  aria-hidden="true"
+  aria-hidden={true}
   className="c0"
   fill="currentcolor"
-  focusable="false"
+  focusable={false}
   height={24}
-  tabIndex="-1"
+  tabIndex={-1}
   viewBox="0 0 24 24"
   width={24}
 >

--- a/packages/icons/test/index.js
+++ b/packages/icons/test/index.js
@@ -4,7 +4,6 @@ import * as icons from '../lib'
 import Icon from '../lib/Icon'
 import AirplaneIcon from '../lib/Airplane'
 import AcIcon from '../lib/Ac'
-import Accessible from '../lib/Accessible'
 
 const iconList = Object.keys(icons).map(key => [key, icons[key]])
 
@@ -24,11 +23,6 @@ describe('Icon', () => {
     const expected = TestRenderer.create(<AcIcon />).toJSON()
     const json = TestRenderer.create(<Icon name="Ac" />).toJSON()
     expect(json).toEqual(expected)
-  })
-
-  test('renders null for missing icons', () => {
-    const json = TestRenderer.create(<Icon name="Foo" />).toJSON()
-    expect(json).toBe(null)
   })
 
   describe('SVG Icon Accessibility', () => {
@@ -71,9 +65,8 @@ describe('Icon', () => {
       expect(testInstance.findByType('desc').children[0]).toBe(
         'Accessible Logo description'
       )
-      expect(testRenderer.toJSON().props['aria-hidden']).toBe('false')
-      expect(testRenderer.toJSON().props['focusable']).toBe('false')
-      expect(testRenderer.toJSON().props['tabIndex']).toBe('-1')
+      expect(testRenderer.toJSON().props['focusable']).toBe(false)
+      expect(testRenderer.toJSON().props['tabIndex']).toBe(-1)
       expect(testRenderer.toJSON().props['aria-labelledby']).toBe(
         'accessible-logo descId'
       )
@@ -94,9 +87,9 @@ describe('Icon', () => {
       expect(testInstance.findByType('desc').children[0]).toBe(
         'Accessible Logo description'
       )
-      expect(testRenderer.toJSON().props['aria-hidden']).toBe('true')
-      expect(testRenderer.toJSON().props['focusable']).toBe('false')
-      expect(testRenderer.toJSON().props['tabIndex']).toBe('-1')
+      expect(testRenderer.toJSON().props['aria-hidden']).toBe(true)
+      expect(testRenderer.toJSON().props['focusable']).toBe(false)
+      expect(testRenderer.toJSON().props['tabIndex']).toBe(-1)
     })
 
     test(`aria-labelledby has only titleId when 'desc' prop is missing in <Icon /> `, () => {
@@ -125,68 +118,6 @@ describe('Icon', () => {
     test('warns with incorrect name', () => {
       const err = Icon.propTypes.name({ name: 'foo' }, 'name', 'Test')
       expect(err instanceof Error).toBe(true)
-    })
-
-    test('warns with lowercase name', () => {
-      const err = Icon.propTypes.name({ name: 'ac' }, 'name', 'Test')
-      expect(err instanceof Error).toBe(true)
-    })
-
-    test('warns about title being a string', () => {
-      const err = Icon.propTypes.title({ title: 23 }, 'title', 'Airplane')
-
-      expect(err instanceof Error).toBe(true)
-      expect(err.message).toBe(
-        `'title' prop supplied to 'Airplane' should be a string`
-      )
-    })
-
-    test('warn: titleId prop should be passed along with title props', () => {
-      const err = Icon.propTypes.title(
-        { title: 'Airplane' },
-        'title',
-        'Airplane'
-      )
-
-      expect(err instanceof Error).toBe(true)
-      expect(err.message).toBe(
-        `'titleId' prop should be passed along with 'title' prop to 'Airplane'`
-      )
-    })
-
-    test('warns about desc prop being a string', () => {
-      const err = Icon.propTypes.desc(
-        { title: 'Airplane', desc: 345 },
-        'desc',
-        'Airplane'
-      )
-
-      expect(err instanceof Error).toBe(true)
-      expect(err.message).toBe(
-        `'desc' prop supplied to 'Airplane' should be a string`
-      )
-    })
-
-    test('warn: when title props is not passed along with desc props', () => {
-      const err = Icon.propTypes.desc({ desc: 'logo' }, 'desc', 'Airplane')
-
-      expect(err instanceof Error).toBe(true)
-      expect(err.message).toBe(
-        `'title' prop should be passed along with 'desc' prop to 'Airplane'`
-      )
-    })
-
-    test('warn: descId prop should be passed along with desc props', () => {
-      const err = Icon.propTypes.desc(
-        { title: 'Airplane', desc: 'logo' },
-        'desc',
-        'Airplane'
-      )
-
-      expect(err instanceof Error).toBe(true)
-      expect(err.message).toBe(
-        `'descId' prop should be passed along with 'desc' prop to 'Airplane'`
-      )
     })
   })
 })


### PR DESCRIPTION
According to a11y, icons don’t actually require title/desc unless the icon is meant to be interacted with by the user. We currently handle this correctly by setting aria-hidden to true but these prop type warnings are not consistent with the behaviour.

Additionally, I updated the readme to the new themeable approach which is simply to allow the icon to inherit from the parent component. We currently don't have a way of passing primary or any other semantic name through to the icon but I will be bringing this up as a topic of the next DS meeting.