### PR TITLE
Core version 2.3.1 with pcln-icons 2.1.0

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-design-system",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-design-system",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Priceline Design System",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "deepmerge": "^4.0.0",
-    "pcln-icons": "^2.0.4",
+    "pcln-icons": "^2.1.0",
     "prop-types": "^15.7.2",
     "styled-system": "^3.2.1"
   },


### PR DESCRIPTION
Updating core to 2.3.1 with pcln-icons 2.1.0, will create a release once merged in.