### PR TITLE
fix: Select arrow in IE11

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "scripts": {
-    "prepare": "rollup --config",
+    "prepare": "npx rollup --config",
     "clean": "rm -rf node_modules dist",
     "test": "jest"
   },

--- a/packages/core/src/Select.js
+++ b/packages/core/src/Select.js
@@ -25,6 +25,9 @@ const SelectBase = styled.select`
     border-color: ${getPaletteColor('base')};
     box-shadow: 0 0 0 1px ${getPaletteColor('base')};
   }
+  ::-ms-expand {
+    display: none;
+  }
 `
 SelectBase.defaultProps = {
   fontSize: 1,

--- a/packages/core/test/__snapshots__/FormField.js.snap
+++ b/packages/core/test/__snapshots__/FormField.js.snap
@@ -466,6 +466,10 @@ exports[`FormField renders with Select  1`] = `
   box-shadow: 0 0 0 1px #007aff;
 }
 
+.c3::-ms-expand {
+  display: none;
+}
+
 <div>
   <div
     className="c0 "
@@ -575,6 +579,10 @@ exports[`FormField renders with Select and Icon 1`] = `
   outline: none;
   border-color: #007aff;
   box-shadow: 0 0 0 1px #007aff;
+}
+
+.c4::-ms-expand {
+  display: none;
 }
 
 <div>

--- a/packages/core/test/__snapshots__/Select.js.snap
+++ b/packages/core/test/__snapshots__/Select.js.snap
@@ -55,6 +55,10 @@ exports[`Select renders 1`] = `
   box-shadow: 0 0 0 1px #007aff;
 }
 
+.c2::-ms-expand {
+  display: none;
+}
+
 <div
   className="c0 c1"
   width={1}


### PR DESCRIPTION
The native select arrow on IE11 was covering our custom icon, this change hides the native one. Also changed the rollup command to be run with `npx`, my terminal was not able to find the rollup executable from .bin without `npx`. Using `npx` makes it more reliable.