### PR TITLE
Added props to Icon element so the PropType check doesn't complain

### DIFF
--- a/packages/core/src/IconButton.js
+++ b/packages/core/src/IconButton.js
@@ -19,7 +19,7 @@ const TransparentButton = styled(Button)`
 const IconButton = ({ name, size, color, ...props }) => (
   <TransparentButton {...props}>
     <div>
-      <Icon name={name} size={size} color={color} />
+      <Icon name={name} size={size} color={color} {...props} />
     </div>
   </TransparentButton>
 )

--- a/packages/core/src/IconButton.js
+++ b/packages/core/src/IconButton.js
@@ -19,7 +19,15 @@ const TransparentButton = styled(Button)`
 const IconButton = ({ name, size, color, ...props }) => (
   <TransparentButton {...props}>
     <div>
-      <Icon name={name} size={size} color={color} {...props} />
+      <Icon
+        name={name}
+        size={size}
+        color={color}
+        title={props.title}
+        desc={props.desc}
+        titleId={props.titleId}
+        descId={props.descId}
+      />
     </div>
   </TransparentButton>
 )

--- a/packages/core/test/__snapshots__/CloseButton.js.snap
+++ b/packages/core/test/__snapshots__/CloseButton.js.snap
@@ -65,6 +65,9 @@ exports[`CloseButton renders without props 1`] = `
       viewBox="0 0 24 24"
       width={24}
     >
+      <title>
+        close
+      </title>
       <path
         d="M19 6.4L17.6 5 12 10.6 6.4 5 5 6.4l5.6 5.6L5 17.6 6.4 19l5.6-5.6 5.6 5.6 1.4-1.4-5.6-5.6L19 6.4z"
       />


### PR DESCRIPTION
Props Check was failing because title, titleId, desc and descId were not being passed down into the `Icon` element from the `TransparentButton` element