### PR TITLE
refactor: update color theme fn per "text" color & migration guide

### DIFF
--- a/docs/pages/Theming.md
+++ b/docs/pages/Theming.md
@@ -489,3 +489,18 @@ global.mountWithTheme = (node, options) => {
 ## Truncate
 
 - No changes required.
+
+## "text" Color Use Case
+
+- If "text" color is used (i.e. `color="text"`), the `bg` prop is required for
+  theming. Palette namespace is also suggested to be provided for both `color` &
+  `bg` props.
+
+```.jsx
+<Box mt={3} color="text.lightest" bg="background.dark">
+  Theme 1: color="text.lightest" value & bg="background.dark"
+</Box>
+<Box mt={3} color="text" bg="background.lighted">
+  Theme 2: color="text" & "bg"="background.lighted"
+</Box>
+```

--- a/packages/core/src/Hug.js
+++ b/packages/core/src/Hug.js
@@ -49,7 +49,7 @@ const Hug = ({ bg, color, p, fontSize, icon, iconDisplay, ...props }) => (
 
 Hug.defaultProps = {
   borderWidth: 1,
-  color: 'secondary',
+  color: 'text.lightest',
   fontSize: 1,
   p: 2
 }

--- a/packages/core/src/theme.js
+++ b/packages/core/src/theme.js
@@ -42,7 +42,7 @@ export const fontWeights = {
 }
 
 export const lineHeights = {
-  standard: 1.5,
+  standard: 1.4,
   display: 1.25
 }
 

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -214,6 +214,11 @@ export const getTextColorOn = name => props => {
   return ''
 }
 
+const getByPalette = props => css`
+  background-color: ${getPaletteColor(props.bg, 'base')(props)};
+  color: ${getPaletteColor(props.color, 'base')(props)};
+`
+
 /**
  * Extended color function from styled-system. First checks
  * for a palette color before falling back to styled-system
@@ -225,11 +230,14 @@ export const getTextColorOn = name => props => {
 export const color = props => {
   if (!props.theme || (!props.color && !props.bg)) {
     return ''
+  } else if (props.color === 'text') {
+    return props.color && props.bg
+      ? getByPalette(props)
+      : css`
+          color: ${getPaletteColor('base')(props)};
+        `
   } else if (props.color && props.bg) {
-    return css`
-      background-color: ${getPaletteColor(props.bg, 'base')(props)};
-      color: ${getPaletteColor(props.color, 'base')(props)};
-    `
+    return getByPalette(props)
   } else if (props.color && hasPaletteColor(props)) {
     return css`
       background-color: ${getPaletteColor('base')(props)};

--- a/packages/core/storybook/Box.js
+++ b/packages/core/storybook/Box.js
@@ -112,8 +112,8 @@ storiesOf('Box', module)
         <Box mt={3} color="text.lightest" bg="background.dark">
           Theme 1: color="text.lightest" value & bg="background.dark"
         </Box>
-        <Box mt={3} color="text" bg="background.lighted">
-          Theme 2: color="text" & "bg"="background.lighted"
+        <Box mt={3} color="text" bg="background.lightest">
+          Theme 2: color="text" & "bg"="background.lightest"
         </Box>
       </Box>
     </React.Fragment>

--- a/packages/core/storybook/Box.js
+++ b/packages/core/storybook/Box.js
@@ -96,3 +96,25 @@ storiesOf('Box', module)
       </Box>
     </Box>
   ))
+  .add('Theme user case: color=text', () => (
+    <React.Fragment>
+      <Box p={3}>
+        <Box mt={3} color="text">
+          color="text" w/o bg prop: retain the original "text" color from
+          original color set as backward compatible: expected style w. "text"
+          color and white background
+        </Box>
+        <Box mt={3} color="purple">
+          color="purple" as none "text" color w/o bg prop
+        </Box>
+      </Box>
+      <Box p={5}>
+        <Box mt={3} color="text.lightest" bg="background.dark">
+          Theme 1: color="text.lightest" value & bg="background.dark"
+        </Box>
+        <Box mt={3} color="text" bg="background.lighted">
+          Theme 2: color="text" & "bg"="background.lighted"
+        </Box>
+      </Box>
+    </React.Fragment>
+  ))

--- a/packages/core/storybook/Box.js
+++ b/packages/core/storybook/Box.js
@@ -100,7 +100,7 @@ storiesOf('Box', module)
     <React.Fragment>
       <Box p={3}>
         <Box mt={3} color="text">
-          color="text" w/o bg prop: retain the original "text" color from
+          color="text" w/o bg prop: retains the original "text" color from
           original color set as backward compatible: expected style w. "text"
           color and white background
         </Box>

--- a/packages/core/test/__snapshots__/Flag.js.snap
+++ b/packages/core/test/__snapshots__/Flag.js.snap
@@ -309,7 +309,7 @@ exports[`Flag renders with theme color as bg color 1`] = `
 
 .c0 {
   font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
-  line-height: 1.5;
+  line-height: 1.4;
   font-weight: 500;
 }
 

--- a/packages/core/test/__snapshots__/Hug.js.snap
+++ b/packages/core/test/__snapshots__/Hug.js.snap
@@ -9,8 +9,8 @@ exports[`Hug renders text, icon, and Child 1`] = `[Function]`;
 exports[`Hug renders with border-radius from theme on top only 1`] = `
 .c3 {
   padding: 8px;
-  background-color: #0a0;
-  color: #fff;
+  background-color: #fff;
+  color: #001833;
 }
 
 .c2 {
@@ -29,7 +29,7 @@ exports[`Hug renders with border-radius from theme on top only 1`] = `
 }
 
 .c1 {
-  border: 1px solid #0a0;
+  border: 1px solid #fff;
   border-radius: 2px;
 }
 
@@ -50,7 +50,7 @@ exports[`Hug renders with border-radius from theme on top only 1`] = `
 >
   <div
     className="c2 c3"
-    color="secondary"
+    color="text.lightest"
   >
     <div
       className="c4"

--- a/packages/core/test/__snapshots__/Radio.js.snap
+++ b/packages/core/test/__snapshots__/Radio.js.snap
@@ -50,7 +50,7 @@ exports[`Radio Disabled, rendering 1`] = `
 
 .c0 {
   font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
-  line-height: 1.5;
+  line-height: 1.4;
   font-weight: 500;
 }
 
@@ -145,7 +145,7 @@ exports[`Radio Not Selected, rendering 1`] = `
 
 .c0 {
   font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
-  line-height: 1.5;
+  line-height: 1.4;
   font-weight: 500;
 }
 
@@ -238,7 +238,7 @@ exports[`Radio Selected, rendering 1`] = `
 
 .c0 {
   font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
-  line-height: 1.5;
+  line-height: 1.4;
   font-weight: 500;
 }
 

--- a/packages/core/test/__snapshots__/ThemeProvider.js.snap
+++ b/packages/core/test/__snapshots__/ThemeProvider.js.snap
@@ -3,7 +3,7 @@
 exports[`ThemeProvider Base component includes a font 1`] = `
 .c0 {
   font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
-  line-height: 1.5;
+  line-height: 1.4;
   font-weight: 500;
 }
 
@@ -23,7 +23,7 @@ exports[`ThemeProvider accepts a custom breakpoints prop 1`] = `
 
 .c0 {
   font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
-  line-height: 1.5;
+  line-height: 1.4;
   font-weight: 500;
 }
 
@@ -62,7 +62,7 @@ exports[`ThemeProvider accepts a custom breakpoints prop 1`] = `
 exports[`ThemeProvider renders 1`] = `
 .c0 {
   font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
-  line-height: 1.5;
+  line-height: 1.4;
   font-weight: 500;
 }
 
@@ -78,7 +78,7 @@ exports[`ThemeProvider renders 1`] = `
 exports[`ThemeProvider renders with legacy prop 1`] = `
 .c0 {
   font-family: 'Montserrat','Helvetica Neue',Helvetica,Arial,sans-serif;
-  line-height: 1.5;
+  line-height: 1.4;
   font-weight: 500;
 }
 

--- a/packages/core/test/__snapshots__/theme.js.snap
+++ b/packages/core/test/__snapshots__/theme.js.snap
@@ -166,7 +166,7 @@ Object {
   },
   "lineHeights": Object {
     "display": 1.25,
-    "standard": 1.5,
+    "standard": 1.4,
   },
   "maxContainerWidth": "1280px",
   "mediaQueries": Array [
@@ -195,17 +195,17 @@ Object {
     "body0": Object {
       "fontSize": "12px",
       "fontWeight": 500,
-      "lineHeight": 1.5,
+      "lineHeight": 1.4,
     },
     "body1": Object {
       "fontSize": "14px",
       "fontWeight": 500,
-      "lineHeight": 1.5,
+      "lineHeight": 1.4,
     },
     "body2": Object {
       "fontSize": "16px",
       "fontWeight": 500,
-      "lineHeight": 1.5,
+      "lineHeight": 1.4,
     },
     "display0": Object {
       "fontSize": "12px",


### PR DESCRIPTION
When `color="text"` is used, `bg` prop is required to support theme. Otherwise, "text" color falls back to use original "text" from original color set.

- update line height standard pellet in theme to 1.4 per @wesleymartin85 

- a new `Box` story - Theme user case: color=text

<img width="1435" alt="Screen Shot 2019-09-18 at 11 33 39 AM" src="https://user-images.githubusercontent.com/6441326/65163147-7b9d2300-da08-11e9-8f99-cbf1dceee47f.png">

- "text" color use case in migration guide

```
"text" Color Use Case

- If "text" color is used (i.e. `color="text"`), the `bg` prop is required for
  theming. Palette namespace is also suggested to be provided for both `color` &
  `bg` props.

<Box mt={3} color="text.lightest" bg="background.dark">
  Theme 1: color="text.lightest" value & bg="background.dark"
</Box>
<Box mt={3} color="text" bg="background.lighted">
  Theme 2: color="text" & "bg"="background.lighted"
</Box>
```
