### PR TITLE
chore: version core 2.3.2

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-design-system",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-design-system",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Priceline Design System",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
Fast-track PR to version core at v2.3.2 for next release.

cc prev reviewers involved for the items in this release, @jes708 / @sdalonzo / @achoboter 

Once CI is green, w. admin write, I'd merge the fast-track version PR to publish a release to move forward with the theme patches.