### PR TITLE
fix: adding-image-height-attribute-precedence

### DIFF
--- a/packages/core/src/Image.js
+++ b/packages/core/src/Image.js
@@ -1,9 +1,10 @@
 import styled from 'styled-components'
 
-const Image = styled.img`
+const Image = styled.img.attrs(props => ({
+  height: 'auto'
+}))`
   display: block;
   max-width: 100%;
-  height: auto;
 `
 
 Image.displayName = 'Image'

--- a/packages/core/test/__snapshots__/Image.js.snap
+++ b/packages/core/test/__snapshots__/Image.js.snap
@@ -4,7 +4,6 @@ exports[`Image renders 1`] = `
 .c0 {
   display: block;
   max-width: 100%;
-  height: auto;
 }
 
 <img


### PR DESCRIPTION
This pr helps to set height attribute precedence 