### PR TITLE
Fix: IconButton Close Hover - #594

### DIFF
--- a/packages/core/src/IconButton.js
+++ b/packages/core/src/IconButton.js
@@ -11,6 +11,7 @@ const TransparentButton = styled(Button)`
 
   &:hover {
     background-color: transparent;
+    color: inherit;
   }
   & > div {
     display: flex;

--- a/packages/core/test/__snapshots__/CloseButton.js.snap
+++ b/packages/core/test/__snapshots__/CloseButton.js.snap
@@ -40,6 +40,7 @@ exports[`CloseButton renders without props 1`] = `
 
 .c0:hover {
   background-color: transparent;
+  color: inherit;
 }
 
 .c0 > div {

--- a/packages/core/test/__snapshots__/IconButton.js.snap
+++ b/packages/core/test/__snapshots__/IconButton.js.snap
@@ -40,6 +40,7 @@ exports[`IconButton renders without props 1`] = `
 
 .c0:hover {
   background-color: transparent;
+  color: inherit;
 }
 
 .c0 > div {

--- a/packages/core/test/__snapshots__/IconField.js.snap
+++ b/packages/core/test/__snapshots__/IconField.js.snap
@@ -150,6 +150,7 @@ exports[`IconField renders icon button 1`] = `
 
 .c2:hover {
   background-color: transparent;
+  color: inherit;
 }
 
 .c2 > div {
@@ -302,6 +303,7 @@ exports[`IconField renders icon, input and icon button together 1`] = `
 
 .c3:hover {
   background-color: transparent;
+  color: inherit;
 }
 
 .c3 > div {


### PR DESCRIPTION
Fixing issue #594 

- added `color: inherit` to the hover of IconButton
