### PR TITLE
Fix unmapped icon handlement

### DIFF
--- a/packages/icons/src/Icon.js
+++ b/packages/icons/src/Icon.js
@@ -10,29 +10,35 @@ const Icon = ({ name, title, desc, titleId, descId, ...props }) => {
   ariaLabelledBy += desc && descId ? ` ${descId}` : ''
   ariaLabelledBy = ariaLabelledBy ? ariaLabelledBy : undefined
 
-  return (
-    Component && (
-      <Component
-        title={title}
-        desc={desc}
-        titleId={titleId}
-        descId={descId}
-        aria-hidden={!!ariaLabelledBy}
-        aria-labelledby={ariaLabelledBy}
-        {...props}
-      />
+  if (!Component) {
+    if (process.env.NODE_ENV !== 'production')
+      console.trace(`icon ${iconName} does not exist`)
+    return null
+  } else {
+    return (
+      Component && (
+        <Component
+          aria-hidden="true"
+          title={title}
+          desc={desc}
+          titleId={titleId}
+          descId={descId}
+          aria-hidden={!!ariaLabelledBy || true}
+          aria-labelledby={ariaLabelledBy}
+          tabIndex={-1}
+          focusable={false}
+          {...props}
+        />
+      )
     )
-  )
+  }
 }
 
 Icon.isIcon = true
 Icon.displayName = 'Icon'
 
 Icon.defaultProps = {
-  size: 24,
-  tabIndex: -1,
-  focusable: false,
-  'aria-hidden': true
+  size: 24
 }
 
 Icon.propTypes = {

--- a/packages/icons/src/Icon.js
+++ b/packages/icons/src/Icon.js
@@ -22,7 +22,7 @@ const Icon = ({ name, title, desc, titleId, descId, ...props }) => {
         desc={desc}
         titleId={titleId}
         descId={descId}
-        aria-hidden={!!ariaLabelledBy || true}
+        aria-hidden={!ariaLabelledBy}
         aria-labelledby={ariaLabelledBy}
         tabIndex={-1}
         focusable={false}

--- a/packages/icons/src/Icon.js
+++ b/packages/icons/src/Icon.js
@@ -17,7 +17,6 @@ const Icon = ({ name, title, desc, titleId, descId, ...props }) => {
   } else {
     return (
       <Component
-        aria-hidden="true"
         title={title}
         desc={desc}
         titleId={titleId}

--- a/packages/icons/src/Icon.js
+++ b/packages/icons/src/Icon.js
@@ -16,20 +16,18 @@ const Icon = ({ name, title, desc, titleId, descId, ...props }) => {
     return null
   } else {
     return (
-      Component && (
-        <Component
-          aria-hidden="true"
-          title={title}
-          desc={desc}
-          titleId={titleId}
-          descId={descId}
-          aria-hidden={!!ariaLabelledBy || true}
-          aria-labelledby={ariaLabelledBy}
-          tabIndex={-1}
-          focusable={false}
-          {...props}
-        />
-      )
+      <Component
+        aria-hidden="true"
+        title={title}
+        desc={desc}
+        titleId={titleId}
+        descId={descId}
+        aria-hidden={!!ariaLabelledBy || true}
+        aria-labelledby={ariaLabelledBy}
+        tabIndex={-1}
+        focusable={false}
+        {...props}
+      />
     )
   }
 }

--- a/packages/icons/src/Icon.js
+++ b/packages/icons/src/Icon.js
@@ -11,8 +11,9 @@ const Icon = ({ name, title, desc, titleId, descId, ...props }) => {
   ariaLabelledBy = ariaLabelledBy ? ariaLabelledBy : undefined
 
   if (!Component) {
-    if (process.env.NODE_ENV !== 'production')
+    if (process.env.NODE_ENV !== 'production') {
       console.trace(`icon ${iconName} does not exist`)
+    }
     return null
   } else {
     return (

--- a/packages/icons/test/index.js
+++ b/packages/icons/test/index.js
@@ -82,16 +82,18 @@ describe('Icon', () => {
         />
       )
       const testInstance = testRenderer.root
-
       const title = testInstance.findAll(el => el.type == 'title')
       expect(title).toHaveLength(0)
       expect(testInstance.findByType('desc').children[0]).toBe(
         'Accessible Logo description'
       )
-      expect(testRenderer.toJSON().props['aria-hidden']).toBe(true)
-      expect(testRenderer.toJSON().props['focusable']).toBe(false)
-      expect(testRenderer.toJSON().props['tabIndex']).toBe(-1)
       expect(testRenderer.toJSON().props['role']).toBe('img')
+
+      const tree = testRenderer.toTree()
+      const renderedProps = tree.rendered.props
+      expect(renderedProps['aria-hidden']).toBeFalsy()
+      expect(renderedProps['focusable']).toBeFalsy()
+      expect(renderedProps['tabIndex']).toBe(-1)
     })
 
     test(`aria-labelledby has only titleId when 'desc' prop is missing in <Icon /> `, () => {


### PR DESCRIPTION
Fixes #610 

Plus rearrange to use less default props for html attributes that could be inline in JSX.

##### Test to validate all existing a11y attributes and retain working icon feature

<img width="898" alt="Screen Shot 2019-10-11 at 5 08 15 PM" src="https://user-images.githubusercontent.com/6441326/66685886-b717bf80-ec4b-11e9-96cf-ec60f78c13c4.png">
