### PR TITLE
fix Icon references in docsite

### DIFF
--- a/docs/IconField.md
+++ b/docs/IconField.md
@@ -1,11 +1,10 @@
-
 # IconField
 
 Group Inputs and Selects with Icons.
 
 ```.jsx
 <IconField>
-  <Icon name='calendar' color='blue' />
+  <Icon name='Calendar' color='blue' />
   <Input
     placeholder='Choose Date'
   />
@@ -17,23 +16,23 @@ Group Inputs and Selects with Icons.
   <Input
     placeholder='Choose Date'
   />
-  <Icon name='calendar' color='blue' />
+  <Icon name='Calendar' color='blue' />
 </IconField>
 ```
 
 ```.jsx
 <IconField>
-  <Icon name='calendar' color='blue' />
+  <Icon name='Calendar' color='blue' />
   <Input
     placeholder='Choose Date'
   />
-  <Icon name='check' color='green' />
+  <Icon name='Check' color='green' />
 </IconField>
 ```
 
 ```.jsx
 <IconField>
-  <Icon name='calendar' color='blue' />
+  <Icon name='Calendar' color='blue' />
   <Select>
     <option>Choose Date</option>
     <option>January 2019</option>
@@ -52,9 +51,10 @@ import CustomInput from './CustomInput'
 
 CustomInput.isField = true
 
-export default props =>
+export default props => (
   <IconField>
-    <Icon name='calendar' />
+    <Icon name="Calendar" />
     <CustomInput {...props} />
   </IconField>
+)
 ```

--- a/docs/pages/Banner.md
+++ b/docs/pages/Banner.md
@@ -14,7 +14,7 @@ Use `Banner` component to create a box with a optional header, text, optional le
   bg='lightBlue'
   p={2}>
   <Flex>
-    <Icon name='calendar' />
+    <Icon name='Calendar' />
     <Box pl={2}>
       <Heading fontSize={2} bold>Are Your Dates Correct?</Heading>
       <Text>
@@ -56,7 +56,7 @@ Uses the color from `theme.palette.primary.base`.
 <Banner
   p={2}
   color="error"
-  iconName="warning"
+  iconName="Warning"
   text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. "
 />
 ```
@@ -67,7 +67,7 @@ Uses the color from `theme.palette.error.base`.
 <Banner
   p={2}
   color="caution"
-  iconName="attention"
+  iconName="Attention"
   text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla cursus pretium turpis nec efficitur. "
 />
 ```

--- a/docs/pages/FormField.md
+++ b/docs/pages/FormField.md
@@ -5,7 +5,7 @@ Use the `FormField` component to combine `Input` or `Select`, `Label`, and `Icon
 ```.jsx
 <FormField>
   <Label htmlFor='email'>Email address</Label>
-  <Icon name='email' size='20' />
+  <Icon name='Email' size='20' />
   <Input
     id='email'
     name='email'
@@ -18,7 +18,7 @@ Use the `FormField` component to combine `Input` or `Select`, `Label`, and `Icon
 ```.jsx
 <FormField>
   <Label htmlFor='options'>Select One</Label>
-  <Icon name='key' size='20' />
+  <Icon name='Key' size='20' />
   <Select
     id='options'
     name='options'>
@@ -47,7 +47,7 @@ Error messages can be displayed using the [`Tooltip`](/Tooltip) component.
   <Input
     value='hello@example'
   />
-  <Icon name='warning' color='red' />
+  <Icon name='Warning' color='red' />
 </FormField>
 <Tooltip
   bottom

--- a/docs/pages/Icon.md
+++ b/docs/pages/Icon.md
@@ -4,7 +4,7 @@ Use the `Icon` component for SVG icons.
 
 ```.jsx
 <Icon
-  name='flame'
+  name='Flame'
   color='orange'
 />
 ```

--- a/docs/pages/IconButton.md
+++ b/docs/pages/IconButton.md
@@ -4,7 +4,7 @@ The `IconButton` component is a `<button>` element with icon.
 
 ```.jsx
 <IconButton
-  name='flame'
+  name='Flame'
   size={24}
   color='orange'
   title='Set on fire'

--- a/docs/pages/Layout.md
+++ b/docs/pages/Layout.md
@@ -218,7 +218,7 @@ In a real application, these would likely be links and buttons.
   color='white'
   bg='blue'>
   <Icon
-    name='hotel'
+    name='Hotels'
     mr={2}
   />
   <Text
@@ -247,7 +247,7 @@ Next, add some padding and use the `align` prop on the parent Flex component to 
   color='white'
   bg='blue'>
   <Icon
-    name='hotel'
+    name='Hotels'
     mr={2}
   />
   <Text

--- a/docs/pages/Stamp.md
+++ b/docs/pages/Stamp.md
@@ -6,7 +6,7 @@ An Icon placed within a Stamp will inherit the assigned Stamp color.
 
 ```.jsx
 <Stamp color='purple'>
-  <Icon name='trendingUp' size={16} mr={1} /> top booked hotel
+  <Icon name='TrendingUp' size={16} mr={1} /> top booked hotel
 </Stamp>
 ```
 

--- a/docs/pages/Theming.md
+++ b/docs/pages/Theming.md
@@ -441,13 +441,13 @@ global.mountWithTheme = (node, options) => {
 
 ```.jsx
 <Stamp color="primary" mr={2}>
-  <Icon name="pin" size={16} mr={1} /> primary stamp
+  <Icon name="Pin" size={16} mr={1} /> primary stamp
 </Stamp>
 <Stamp color="error" mr={2}>
-  <Icon name="warning" size={16} mr={1} /> error stamp
+  <Icon name="Warning" size={16} mr={1} /> error stamp
 </Stamp>
 <Stamp color="caution" bg="background.dark" borderColor="caution">
-  <Icon name="information" size={16} mr={1} /> just booked
+  <Icon name="Information" size={16} mr={1} /> just booked
 </Stamp>
 ```
 


### PR DESCRIPTION
most of these just clear warnings with the initial capital - the one that was actually broken was in `Layout`, it referred to `hotel` when the icon is called `Hotels`