### PR TITLE
Fixed undefined bug on IconName var

### DIFF
--- a/packages/icons/src/Icon.js
+++ b/packages/icons/src/Icon.js
@@ -12,7 +12,7 @@ const Icon = ({ name, title, desc, titleId, descId, ...props }) => {
 
   if (!Component) {
     if (process.env.NODE_ENV !== 'production') {
-      console.trace(`icon ${iconName} does not exist`)
+      console.trace(`icon${name ? ' ' + name + ' ' : ' '}does not exist`)
     }
     return null
   } else {

--- a/packages/icons/src/Icon.js
+++ b/packages/icons/src/Icon.js
@@ -12,7 +12,9 @@ const Icon = ({ name, title, desc, titleId, descId, ...props }) => {
 
   if (!Component) {
     if (process.env.NODE_ENV !== 'production') {
-      console.trace(`icon${name ? ' ' + name + ' ' : ' '}does not exist`)
+      console.trace(
+        name ? `icon ${name} does not exist` : 'icon is missing name prop'
+      )
     }
     return null
   } else {


### PR DESCRIPTION
using a ternary to key off of the name passed in as a prop. tested 3 scenarios: blank string, wrong icon name, no prop at all. all worked and gave the props message.