### PR TITLE
Version pcln-icons v2.2.2

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcln-icons",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Priceline React icons based on Material Design Icons",
   "main": "lib/Icon.js",
   "scripts": {


### PR DESCRIPTION
- version packages/icons for pcln-icons v2.2.2
- no lock file
- next PR will follow up to use pcln-icons v2.2.2 for core and doc site