### PR TITLE
Fix: Reverting GreenButton and OutlineButton to styled-components

### DIFF
--- a/packages/core/src/GreenButton.js
+++ b/packages/core/src/GreenButton.js
@@ -1,11 +1,10 @@
-import React from 'react'
+import styled from 'styled-components'
 import Button from './Button'
 
-const GreenButton = ({ children, ...props }) => (
-  <Button color="secondary" {...props}>
-    {children}
-  </Button>
-)
+const GreenButton = styled(Button).attrs({
+  color: 'secondary',
+  variation: 'fill'
+})``
 
 GreenButton.displayName = 'GreenButton'
 

--- a/packages/core/src/OutlineButton.js
+++ b/packages/core/src/OutlineButton.js
@@ -1,11 +1,10 @@
-import React from 'react'
+import styled from 'styled-components'
 import Button from './Button'
 
-const OutlineButton = ({ children, ...props }) => (
-  <Button variation="outline" {...props}>
-    {children}
-  </Button>
-)
+const OutlineButton = styled(Button).attrs({
+  color: 'primary',
+  variation: 'outline'
+})``
 
 OutlineButton.displayName = 'OutlineButton'
 

--- a/packages/core/test/GreenButton.js
+++ b/packages/core/test/GreenButton.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import styled from 'styled-components'
 import { GreenButton, theme } from '../src'
 
 describe('GreenButton', () => {
@@ -19,5 +20,19 @@ describe('GreenButton', () => {
     expect(json).toHaveStyleRule('background-color', theme.colors.darkGreen, {
       modifier: ':hover'
     })
+  })
+
+  test('renders with nested style', () => {
+    const Component = styled.div`
+      ${GreenButton} {
+        color: red;
+      }
+    `
+    const wrapper = rendererCreateWithTheme(
+      <Component>
+        <GreenButton />
+      </Component>
+    ).toJSON()
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/packages/core/test/OutlineButton.js
+++ b/packages/core/test/OutlineButton.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { OutlineButton, theme } from '../src'
+import styled from 'styled-components'
 
 describe('OutlineButton', () => {
   test('renders', () => {
@@ -19,5 +20,19 @@ describe('OutlineButton', () => {
     expect(json).toHaveStyleRule('color', theme.colors.darkBlue, {
       modifier: ':hover'
     })
+  })
+
+  test('renders with nested style', () => {
+    const Component = styled.div`
+      ${OutlineButton} {
+        color: red;
+      }
+    `
+    const wrapper = rendererCreateWithTheme(
+      <Component>
+        <OutlineButton />
+      </Component>
+    ).toJSON()
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/packages/core/test/__snapshots__/GreenButton.js.snap
+++ b/packages/core/test/__snapshots__/GreenButton.js.snap
@@ -64,6 +64,46 @@ exports[`GreenButton renders 1`] = `
 />
 `;
 
+exports[`GreenButton renders with nested style 1`] = `
+.c2 {
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.5;
+  cursor: pointer;
+  border-radius: 2px;
+  border-width: 0;
+  border-style: solid;
+  font-size: 14px;
+  padding: 9.5px 18px;
+  background-color: #0a0;
+  color: #fff;
+}
+
+.c2:hover {
+  background-color: #060;
+  color: #fff;
+}
+
+.c0 .c1 {
+  color: red;
+}
+
+<div
+  className="c0"
+>
+  <button
+    className="c1 c2"
+    color="secondary"
+  />
+</div>
+`;
+
 exports[`GreenButton without disabled prop sets 1`] = `
 .c0 {
   -webkit-font-smoothing: antialiased;

--- a/packages/core/test/__snapshots__/OutlineButton.js.snap
+++ b/packages/core/test/__snapshots__/OutlineButton.js.snap
@@ -67,6 +67,48 @@ exports[`OutlineButton renders 1`] = `
 />
 `;
 
+exports[`OutlineButton renders with nested style 1`] = `
+.c2 {
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.5;
+  cursor: pointer;
+  border-radius: 2px;
+  border-width: 0;
+  border-style: solid;
+  font-size: 14px;
+  padding: 9.5px 18px;
+  color: #007aff;
+  box-shadow: inset 0 0 0 2px #007aff;
+  background-color: transparent;
+}
+
+.c2:hover {
+  background-color: transparent;
+  color: #049;
+  box-shadow: inset 0 0 0 2px #049;
+}
+
+.c0 .c1 {
+  color: red;
+}
+
+<div
+  className="c0"
+>
+  <button
+    className="c1 c2"
+    color="primary"
+  />
+</div>
+`;
+
 exports[`OutlineButton without disabled prop sets 1`] = `
 .c0 {
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
`GreenButton` and `OutlineButton` were recently switch to functional components which broke any uses of the components when they are nested into another styled-component.

For example:

```.js
const StyledBox = styled(Box)`
  ${GreenButton} {
    background-color: red;
  }
`;
```

Currently breaks because `GreenButton` isn't a styled-component. This PR reverts these components back to a styled-component so they can be nested.